### PR TITLE
[WIP] Rework handle_event into an event iterator

### DIFF
--- a/src/control/crtc.rs
+++ b/src/control/crtc.rs
@@ -149,75 +149,81 @@ pub fn page_flip<T, U>(device: &T, handle: Handle, fb: FBHandle, flags: &[PageFl
     Ok(())
 }
 
-/// Handles vblank events
-pub trait VblankHandler<T: control::Device> {
-    /// Called per vblank event
-    fn handle_event(&mut self, device: &T, frame: u32, duration: Duration, userdata: Box<Any>);
+/// Iterator over `DrmEvent`s of a device. Create via `recieve_events`.
+pub struct DrmEvents {
+    event_buf: [u8; 1024],
+    amount: usize,
+    i: usize,
 }
 
-impl<T, F> VblankHandler<T> for F
-    where T: control::Device, F: FnMut(&T, u32, Duration, Box<Any>) {
+/// An event from a device.
+pub enum DrmEvent {
+    /// A vblank happened
+    Vblank(VblankEvent),
+    /// A page flip happened
+    PageFlip(PageFlipEvent),
+}
 
-    fn handle_event(&mut self, device: &T, frame: u32, duration: Duration, userdata: Box<Any>) {
-        (*self)(device, frame, duration, userdata)
+/// Vblank event
+pub struct VblankEvent {
+    /// sequence of the frame
+    pub frame: u32,
+    /// duration between events
+    pub duration: Duration,
+    /// userdata as passed into `page_flip`
+    pub userdata: Box<Any>,
+}
+
+/// Page Flip event
+pub struct PageFlipEvent {
+    /// sequence of the frame
+    pub frame: u32,
+    /// duration between events
+    pub duration: Duration,
+    /// crtc that did throw the event, if available by the driver
+    pub crtc: Option<Handle>,
+    /// userdata as passed into `page_flip`
+    pub userdata: Box<Any>,
+}
+
+impl Iterator for DrmEvents {
+    type Item = DrmEvent;
+
+    fn next(&mut self) -> Option<DrmEvent> {
+        while self.amount > 0 && self.i < self.amount {
+            let event = unsafe { &*(self.event_buf.as_ptr().offset(self.i as isize) as *const ffi::drm_event) };
+            self.i += event.length as usize;
+            match event.type_ {
+                x if x == ffi::DRM_EVENT_VBLANK => {
+                    let vblank_event: &ffi::drm_event_vblank = unsafe { mem::transmute(event) };
+                    let userdata = unsafe { Box::from_raw(vblank_event.user_data as *mut FatPtrWrapper).0 };
+                    return Some(DrmEvent::Vblank(VblankEvent {
+                        frame: vblank_event.sequence,
+                        duration: Duration::new(vblank_event.tv_sec as u64, vblank_event.tv_usec * 100),
+                        userdata,
+                    }));
+                },
+                x if x == ffi::DRM_EVENT_FLIP_COMPLETE => {
+                    let vblank_event: &ffi::drm_event_vblank = unsafe { mem::transmute(event) };
+                    let userdata = unsafe { Box::from_raw(vblank_event.user_data as *mut FatPtrWrapper).0 };
+                    return Some(DrmEvent::PageFlip(PageFlipEvent {
+                        frame: vblank_event.sequence,
+                        duration: Duration::new(vblank_event.tv_sec as u64, vblank_event.tv_usec * 1000),
+                        crtc: if vblank_event.crtc_id != 0 { Some(Handle::from_raw(vblank_event.crtc_id)) } else { None },
+                        userdata
+                    }));
+                },
+                _ => continue,
+            }
+        }
+        None
     }
 }
 
-impl<T> VblankHandler<T> for ()
-    where T: control::Device {
-
-    fn handle_event(&mut self, _: &T, _: u32, _: Duration, _: Box<Any>) {}
-}
-
-/// Handles page flip events
-pub trait PageFlipHandler<T: control::Device> {
-    /// Called per page flip event
-    fn handle_event(&mut self, device: &T, frame: u32, duration: Duration, userdata: Box<Any>);
-}
-
-impl<T, F> PageFlipHandler<T> for F
-    where T: control::Device, F: FnMut(&T, u32, Duration, Box<Any>) {
-
-    fn handle_event(&mut self, device: &T, frame: u32, duration: Duration, userdata: Box<Any>) {
-        (*self)(device, frame, duration, userdata)
-    }
-}
-
-impl<T> PageFlipHandler<T> for ()
-    where T: control::Device {
-
-    fn handle_event(&mut self, _: &T, _: u32, _: Duration, _: Box<Any>) {}
-}
-
-/// Handles page flip events
-pub trait PageFlipHandler2<T: control::Device> {
-    /// Called per page flip event
-    fn handle_event(&mut self, device: &T, frame: u32, duration: Duration, crtc: Handle, userdata: Box<Any>);
-}
-
-impl<T, F> PageFlipHandler2<T> for F
-    where T: control::Device, F: FnMut(&T, u32, Duration, Handle, Box<Any>) {
-
-    fn handle_event(&mut self, device: &T, frame: u32, duration: Duration, crtc: Handle, userdata: Box<Any>) {
-        (*self)(device, frame, duration, crtc, userdata)
-    }
-}
-
-impl<T> PageFlipHandler2<T> for ()
-    where T: control::Device {
-
-    fn handle_event(&mut self, _: &T, _: u32, _: Duration, _: Handle, _: Box<Any>) {}
-}
-
-/// Handles all pending events of a given device.
-///
-/// You need to set a handler for every event type you want to receive.
-/// `pageflip_handler2` is not required, `pageflip_handler` however is required
-/// even if `pageflip_handler2` is set, in case the new api is not supported,
-/// if you want to receive those events guaranteed.
-pub fn handle_event<T, V, P, P2>(device: &T, mut vblank_handler: Option<&mut V>, mut pageflip_handler: Option<&mut P>, mut pageflip_handler2: Option<&mut P2>) -> Result<()>
-    where T: control::Device, V: VblankHandler<T>, P: PageFlipHandler<T>, P2: PageFlipHandler2<T> {
-
+/// Recieves all pending events of a given device and returns an Iterator for them.
+pub fn recieve_events<T>(device: &T) -> Result<DrmEvents>
+    where T: control::Device,
+{
     struct DeviceWrapper<'a, T: control::Device + 'a>(&'a T);
     impl<'a, T: control::Device> Read for DeviceWrapper<'a, T> {
         fn read(&mut self, buf: &mut [u8]) -> ::std::io::Result<usize> {
@@ -233,59 +239,12 @@ pub fn handle_event<T, V, P, P2>(device: &T, mut vblank_handler: Option<&mut V>,
 
     let mut event_buf: [u8; 1024] = [0; 1024];
     let amount = try!(wrapper.read(&mut event_buf));
-    if amount > 0 {
-        let mut i = 0isize;
-        while i < amount as isize {
-            let event = unsafe { &*(event_buf.as_ptr().offset(i) as *const ffi::drm_event) };
-            match event.type_ {
-                x if x == ffi::DRM_EVENT_VBLANK => {
-                    if let Some(handler) = vblank_handler.as_mut() {
-                        let vblank_event: &ffi::drm_event_vblank = unsafe { mem::transmute(event) };
-                        let userdata = unsafe { Box::from_raw(vblank_event.user_data as *mut FatPtrWrapper).0 };
-                        (*handler).handle_event(
-                            wrapper.0,
-                            vblank_event.sequence,
-                            Duration::new(vblank_event.tv_sec as u64, vblank_event.tv_usec * 1000),
-                            userdata
-                        );
-                    }
-                },
-                x if x == ffi::DRM_EVENT_FLIP_COMPLETE => {
-                    let vblank_event: &ffi::drm_event_vblank = unsafe { mem::transmute(event) };
-                    let userdata = unsafe { Box::from_raw(vblank_event.user_data as *mut FatPtrWrapper).0 };
-                    if vblank_event.crtc_id != 0 {
-                        if let Some(handler) = pageflip_handler2.as_mut() {
-                            (*handler).handle_event(
-                                wrapper.0,
-                                vblank_event.sequence,
-                                Duration::new(vblank_event.tv_sec as u64, vblank_event.tv_usec * 1000),
-                                Handle::from_raw(vblank_event.crtc_id),
-                                userdata
-                            );
-                        } else if let Some(handler) = pageflip_handler.as_mut() {
-                            (*handler).handle_event(
-                                &wrapper.0,
-                                vblank_event.sequence,
-                                Duration::new(vblank_event.tv_sec as u64, vblank_event.tv_usec * 1000),
-                                userdata
-                            );
-                        }
-                    } else if let Some(handler) = pageflip_handler.as_mut() {
-                        (*handler).handle_event(
-                            &wrapper.0,
-                            vblank_event.sequence,
-                            Duration::new(vblank_event.tv_sec as u64, vblank_event.tv_usec * 1000),
-                            userdata
-                        );
-                    }
-                },
-                _ => {},
-            }
-            i += event.length as isize;
-        }
-    }
 
-    Ok(())
+    Ok(DrmEvents {
+        event_buf,
+        amount,
+        i: 0,
+    })
 }
 
 /// Sets a hardware-cursor on the given crtc with the image of a given buffer

--- a/src/control/crtc.rs
+++ b/src/control/crtc.rs
@@ -149,15 +149,15 @@ pub fn page_flip<T, U>(device: &T, handle: Handle, fb: FBHandle, flags: &[PageFl
     Ok(())
 }
 
-/// Iterator over `DrmEvent`s of a device. Create via `recieve_events`.
-pub struct DrmEvents {
+/// Iterator over `Event`s of a device. Create via `receive_events`.
+pub struct Events {
     event_buf: [u8; 1024],
     amount: usize,
     i: usize,
 }
 
 /// An event from a device.
-pub enum DrmEvent {
+pub enum Event {
     /// A vblank happened
     Vblank(VblankEvent),
     /// A page flip happened
@@ -188,10 +188,10 @@ pub struct PageFlipEvent {
     pub userdata: Box<Any>,
 }
 
-impl Iterator for DrmEvents {
-    type Item = DrmEvent;
+impl Iterator for Events {
+    type Item = Event;
 
-    fn next(&mut self) -> Option<DrmEvent> {
+    fn next(&mut self) -> Option<Event> {
         if self.amount > 0 && self.i < self.amount {
             let event = unsafe { &*(self.event_buf.as_ptr().offset(self.i as isize) as *const ffi::drm_event) };
             self.i += event.length as usize;
@@ -223,8 +223,8 @@ impl Iterator for DrmEvents {
     }
 }
 
-/// Recieves all pending events of a given device and returns an Iterator for them.
-pub fn recieve_events<T>(device: &T) -> Result<DrmEvents>
+/// Receives all pending events of a given device and returns an Iterator for them.
+pub fn receive_events<T>(device: &T) -> Result<Events>
     where T: control::Device,
 {
     struct DeviceWrapper<'a, T: control::Device + 'a>(&'a T);
@@ -243,7 +243,7 @@ pub fn recieve_events<T>(device: &T) -> Result<DrmEvents>
     let mut event_buf: [u8; 1024] = [0; 1024];
     let amount = try!(wrapper.read(&mut event_buf));
 
-    Ok(DrmEvents {
+    Ok(Events {
         event_buf,
         amount,
         i: 0,


### PR DESCRIPTION
Ref #15.

This is untested, so I do not feel comfortably merging, but I wanted to get a quick feedback from you @Slabity, if this is going into the right direction from your perspective.

This is basically how everything worked before just wrapped into an iterator, so I am quite confident, that it will most likely work, but I noticed a hole in my earlier implementation.

If there are more events then fit into 1024 bytes, they will be thrown away (which should not happen usually, but is kinda bad, I took that value from libdrm, so most programs today seem to be fine with it). I think we can do better, but it is hard in rust, as there is no way to check how much bytes I can read without blocking the device. I basically need to know, how many bytes are available and then read exactly those.

Do you have a good idea how that could be done? I think the FIONREAD ioctl should make this possible, so I am thinking about adding that to src/ffi.rs. Thoughts?