### PR TITLE
Add getter for `vrefresh` to `Mode`

### DIFF
--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -319,6 +319,11 @@ impl Mode {
         self.mode.vscan
     }
 
+    /// Returns the vertical refresh rate of this mode
+    pub fn vrefresh(&self) -> u32 {
+        self.mode.vrefresh
+    }
+
     /// Returns the name of the mode.
     pub fn name(&self) -> &CStr {
         unsafe { CStr::from_ptr(&self.mode.name as *const _) }


### PR DESCRIPTION
Sorry to bother you again,
but it seems there is no way currently to get the refresh rate of a `Mode`.

I have added a getter for it.