### PR TITLE
Allow `Buffer`s passed as reference to be unsized

### DIFF
--- a/src/control/crtc.rs
+++ b/src/control/crtc.rs
@@ -296,7 +296,7 @@ where
 pub fn set_cursor<T, B>(device: &T, handle: Handle, buffer: &B) -> Result<()>
 where
     T: control::Device,
-    B: buffer::Buffer,
+    B: buffer::Buffer + ?Sized,
 {
     let dimensions = buffer.size();
 
@@ -319,7 +319,7 @@ where
 pub fn set_cursor2<T, B>(device: &T, handle: Handle, buffer: &B, hotspot: iPoint) -> Result<()>
 where
     T: control::Device,
-    B: buffer::Buffer,
+    B: buffer::Buffer + ?Sized,
 {
     let dimensions = buffer.size();
 

--- a/src/control/framebuffer.rs
+++ b/src/control/framebuffer.rs
@@ -78,7 +78,7 @@ impl ResourceInfo for Info {
 pub fn create<T, U>(device: &T, buffer: &U) -> Result<Info>
 where
     T: control::Device,
-    U: super::super::buffer::Buffer,
+    U: super::super::buffer::Buffer + ?Sized,
 {
     let framebuffer = {
         let mut raw: ffi::drm_mode_fb_cmd2 = Default::default();

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -66,7 +66,7 @@ pub trait Device: Sized + super::Device {
     /// [`framebuffer::Info`]: framebuffer/Info.t.html
     fn create_framebuffer<U>(&self, buffer: &U) -> Result<framebuffer::Info>
     where
-        U: super::buffer::Buffer,
+        U: super::buffer::Buffer + ?Sized,
     {
         framebuffer::create(self, buffer)
     }


### PR DESCRIPTION
This removes the requirement of `Buffer`s to be sized, when passed as a reference.
`drm-rs` only calls into the trait methods anyway.

I know that development is happening on another branch, but I have no idea how close that is to a release. This PR would be a nice quality of life improvement for `smithay` right now, so if you do not see any problems, I would be very happy to see a 0.3.4 release.