### PR TITLE
Fix some issues when building for ARM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,13 @@ license = "MIT"
 authors = ["Tyler Slabinski <tslabinski@slabity.net>"]
 
 [dependencies]
-drm-sys = "0.0.9"
 nix = "0.8.1"
 derive_more = "0.7.1"
+drm-sys = "0.0.9"
 
 [dependencies.error-chain]
 version = "0.11.0"
 default-features = false
+
+[features]
+use_bindgen = ["drm-sys/use_bindgen"]

--- a/src/control/dumbbuffer.rs
+++ b/src/control/dumbbuffer.rs
@@ -8,6 +8,7 @@ use ffi;
 use result::*;
 use control;
 use buffer;
+use nix::libc;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 /// Slow, but generic `Buffer` implementation
@@ -93,7 +94,7 @@ impl DumbBuffer {
             let flags = mman::MAP_SHARED;
             let length = self.length;
             let fd = device.as_raw_fd();
-            let offset = raw.offset as i64;
+            let offset = raw.offset as libc::off_t;
             try!(mman::mmap(addr, length, prot, flags, fd, offset))
         };
 

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -1,5 +1,6 @@
 use result::*;
 use ffi;
+use nix::libc;
 use std::ffi::CStr;
 use std::hash::{Hash, Hasher};
 pub mod connector;
@@ -15,7 +16,7 @@ pub type RawHandle = u32;
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, From, Into)]
 /// An array to hold the name of a property.
-pub struct RawName([i8; 32]);
+pub struct RawName([libc::c_char; 32]);
 
 /// A trait for devices that provide control (modesetting) functionality.
 pub trait Device: Sized + super::Device {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -18,7 +18,7 @@ macro_rules! ffi_buf {
             use std::mem;
 
             let mut buf = unsafe { vec![mem::zeroed(); $sz as usize] };
-            *(&mut $ptr) = unsafe { mem::transmute(buf.as_mut_ptr()) };
+            *(&mut $ptr) = unsafe { buf.as_mut_ptr() as u64};
             buf
         }
     )


### PR DESCRIPTION
- Export the `use_bindgen` feature at the top level, so non-86x targets can enable it.
- Use the `nix` types, `c_char`, and `off_t`, which seem to be slightly different on ARM.
- Replace one instance of `mem::transmute` with plain cast.