### PR TITLE
Reimplement gamma functions

### DIFF
--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -382,6 +382,50 @@ pub trait Device: super::Device {
 
         Ok(prop_val_set)
     }
+    
+    /// Receive the currently set gamma ramp of a crtc
+    fn get_gamma(&self, crtc: crtc::Handle, red: &mut [u16], green: &mut [u16], blue: &mut [u16]) -> Result<(), SystemError> {
+        let crtc_info = self.get_crtc(crtc)?;
+        if crtc_info.gamma_length as usize > red.len() ||
+           crtc_info.gamma_length as usize > green.len() ||
+           crtc_info.gamma_length as usize > blue.len()
+        {
+            return Err(SystemError::InvalidArgument);
+        }
+
+        ffi::mode::get_gamma(
+            self.as_raw_fd(),
+            crtc.as_ref().get(),
+            crtc_info.gamma_length as usize,
+            red,
+            green,
+            blue
+        )?;
+
+        Ok(())
+    }
+
+    /// Set a gamma ramp for the given crtc
+    fn set_gamma(&self, crtc: crtc::Handle, red: &[u16], green: &[u16], blue: &[u16]) -> Result<(), SystemError> {
+        let crtc_info = self.get_crtc(crtc)?;
+        if crtc_info.gamma_length as usize > red.len() ||
+           crtc_info.gamma_length as usize > green.len() ||
+           crtc_info.gamma_length as usize > blue.len()
+        {
+            return Err(SystemError::InvalidArgument);
+        }
+        
+        ffi::mode::set_gamma(
+            self.as_raw_fd(),
+            crtc.as_ref().get(),
+            crtc_info.gamma_length as usize,
+            red,
+            green,
+            blue
+        )?;
+
+        Ok(())
+    }
 }
 
 /// The set of [ResourceHandles](ResourceHandle.t.html) that a


### PR DESCRIPTION
Another quick reimplementation.

In #25 you mention, that you do not want to do any memory allocations in drm-rs anymore, which is why I removed the previously existing `GammaRamp` struct (containing `Box<[u16]>` color ramps) and used slices instead.

This gives us a c-style-output-argument function signature for `get_gamma`, but I was unable to come up with a better solution, since the gamma_length can vary between devices (and theoretically CRTCs of the same device).