### PR TITLE
Implement prime fd to/from handle conversion

### DIFF
--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -44,6 +44,7 @@ pub mod property;
 use self::dumbbuffer::*;
 use buffer;
 use std::mem;
+use std::os::unix::io::RawFd;
 
 use core::num::NonZeroU32;
 pub type RawResourceHandle = NonZeroU32;
@@ -642,6 +643,18 @@ pub trait Device: super::Device {
             unsafe { tm(&mut *req.props) },
             &mut *req.values,
         )
+    }
+
+    /// Convert a prime file descriptor to a GEM buffer handle
+    fn prime_fd_to_buffer(&self, fd: RawFd) -> Result<buffer::Handle, SystemError> {
+        let info = ffi::gem::fd_to_handle(self.as_raw_fd(), fd)?;
+        Ok(unsafe { mem::transmute(info.handle) })
+    }
+
+    /// Convert a prime file descriptor to a GEM buffer handle
+    fn buffer_to_prime_fd(&self, handle: buffer::Handle, flags: u32) -> Result<RawFd, SystemError> {
+        let info = ffi::gem::handle_to_fd(self.as_raw_fd(), handle.into(), flags)?;
+        Ok(info.fd)
     }
 }
 


### PR DESCRIPTION
Again building on the buffer implementation in #33, allowing to convert between buffer handles and prime file descriptors.