### PR TITLE
Add new buffer traits

### DIFF
--- a/src/buffer/format.rs
+++ b/src/buffer/format.rs
@@ -1,6 +1,6 @@
 //! Color formats using standard FourCC.
 
-use ffi::fourcc::*;
+use drm_ffi::fourcc::*;
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 #[allow(missing_docs)]

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -103,3 +103,25 @@ pub trait PlanarBuffer {
     /// The offsets of the buffer.
     fn offsets(&self) -> [u32; 4];
 }
+
+impl<B: Buffer> PlanarBuffer for B {
+    fn size(&self) -> (u32, u32) {
+        Buffer::size(self)
+    }
+
+    fn format(&self) -> format::PixelFormat {
+        Buffer::format(self)
+    }
+
+    fn pitches(&self) -> [u32; 4] {
+        [self.pitch(), 0, 0, 0]
+    }
+
+    fn handles(&self) -> [Option<Handle>; 4] {
+        [Some(self.handle()), None, None, None]
+    }
+
+    fn offsets(&self) -> [u32; 4] {
+        [0; 4]
+    }
+}

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -88,11 +88,18 @@ pub trait Buffer {
     fn handle(&self) -> Handle;
 }
 
-/*
 /// Planar buffers are buffers where each channel/plane is in its own buffer.
 ///
 /// Each plane has their own handle, pitch, and offsets.
 pub trait PlanarBuffer {
-    // TODO
+    /// The width and height of the buffer.
+    fn size(&self) -> (u32, u32);
+    /// The format of the buffer.
+    fn format(&self) -> format::PixelFormat;
+    /// The pitches of the buffer.
+    fn pitches(&self) -> [u32; 4];
+    /// The handles to the buffer.
+    fn handles(&self) -> [Option<Handle>; 4];
+    /// The offsets of the buffer.
+    fn offsets(&self) -> [u32; 4];
 }
-*/

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -39,6 +39,7 @@ pub mod plane;
 
 pub mod property;
 
+use buffer;
 use std::mem;
 
 use core::num::NonZeroU32;
@@ -434,6 +435,18 @@ pub trait Device: super::Device {
             blue
         )?;
 
+        Ok(())
+    }
+
+    /// Open a GEM buffer handle by name
+    fn open_buffer(&self, name: buffer::Name) -> Result<buffer::Handle, SystemError> {
+        let info = drm_ffi::gem::open(self.as_raw_fd(), name.into())?;
+        Ok(unsafe { mem::transmute(info.handle) })
+    }
+
+    /// Close a GEM buffer handle
+    fn close_buffer(&self, handle: buffer::Handle) -> Result<(), SystemError> {
+        let _info = drm_ffi::gem::close(self.as_raw_fd(), handle.into())?;
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ extern crate drm_ffi;
 pub(crate) mod util;
 
 pub mod control;
-//pub mod buffer;
+pub mod buffer;
 
 use std::os::unix::io::AsRawFd;
 


### PR DESCRIPTION
Split off commits of earlier revisions of PRs #33 and #36.
Allows for easier cherry-picking and discussion.

- [x] Move the `ResourceHandle` and `ResourceType` into the crate root to be used by the buffer module
- [x] Finish the implementation of the `Buffer` trait
- [x] Finish the implementation of the `PlanarBuffer` traits
- [x] Implement `open_buffer` and `close_buffer`
- [ ] `flink` is deprecated and not (yet) implemented
- [x] Add a `PlanarBuffer` implementation for every `Buffer`, since every Buffer is a single-plane buffer