### PR TITLE
example/properties: Add image dep

### DIFF
--- a/examples/properties.rs
+++ b/examples/properties.rs
@@ -1,4 +1,5 @@
 extern crate drm;
+extern crate image;
 
 /// Check the `util` module to see how the `Card` structure is implemented.
 pub mod utils;


### PR DESCRIPTION
Fixup the properties example, that does not compile anymore, because utils depends on image.