### PR TITLE
Add plane types

### DIFF
--- a/drm-ffi/drm-sys/src/lib.rs
+++ b/drm-ffi/drm-sys/src/lib.rs
@@ -18,3 +18,7 @@ include!(concat!("platforms/linux/x86_64/bindings.rs"));
 include!(concat!("platforms/freebsd/x86_64/bindings.rs"));
 
 pub mod fourcc;
+
+pub const DRM_PLANE_TYPE_OVERLAY: u32 = 0;
+pub const DRM_PLANE_TYPE_PRIMARY: u32 = 1;
+pub const DRM_PLANE_TYPE_CURSOR:  u32 = 2;

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -788,6 +788,14 @@ impl std::fmt::Debug for ModeList {
     }
 }
 
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PlaneType {
+    Overlay = ffi::DRM_PLANE_TYPE_OVERLAY,
+    Primary = ffi::DRM_PLANE_TYPE_PRIMARY,
+    Cursor = ffi::DRM_PLANE_TYPE_CURSOR,
+}
+
 /// Wrapper around a set of property IDs and their raw values.
 #[derive(Debug, Copy, Clone)]
 pub struct PropertyValueSet {


### PR DESCRIPTION
Plane types are `#define`d in `libdrm` and therefor not picked up by bindgen or similar.
This PR adds them manually.