### PR TITLE
connector: add supported modes

### DIFF
--- a/src/control/connector.rs
+++ b/src/control/connector.rs
@@ -52,6 +52,7 @@ pub struct Info {
     pub(crate) interface_id: u32,
     pub(crate) connection: State,
     pub(crate) size: Option<(u32, u32)>,
+    pub(crate) modes: [control::Mode; 16],
     pub(crate) encoders: [Option<control::encoder::Handle>; 3],
     pub(crate) curr_enc: Option<control::encoder::Handle>,
 }
@@ -88,6 +89,10 @@ impl Info {
     /// Returns a list of encoders that can be possibly used by this connector.
     pub fn encoders(&self) -> &[Option<control::encoder::Handle>] {
         &self.encoders
+    }
+
+    pub fn modes(&self) ->  &[control::Mode] {
+        &self.modes
     }
 
     /// Returns the current encoder attached to this connector.

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -133,13 +133,15 @@ pub trait Device: super::Device {
         // Maximum number of encoders is 3 due to kernel restrictions
         let mut encoders = [0u32; 3];
         let mut enc_slice = &mut encoders[..];
+        let mut modes = [unsafe { mem::zeroed() }; 16];
+        let mut modes_slice = &mut modes[..];
 
         let ffi_info = ffi::mode::get_connector(
             self.as_raw_fd(),
             handle.into(),
             None,
             None,
-            None,
+            Some(&mut modes_slice),
             Some(&mut enc_slice),
             )?;
 
@@ -152,6 +154,7 @@ pub trait Device: super::Device {
                 (0, 0) => None,
                 (x, y) => Some((x, y)),
             },
+            modes: unsafe { mem::transmute(modes) },
             encoders: unsafe { mem::transmute(encoders) },
             curr_enc: unsafe { mem::transmute(ffi_info.encoder_id) },
         };


### PR DESCRIPTION
Currently limited to 16 at max. No idea, what the actual limit is. Should be enough in most cases.