### PR TITLE
str_internals: remove feature requirement

### DIFF
--- a/drm-ffi/src/lib.rs
+++ b/drm-ffi/src/lib.rs
@@ -4,7 +4,6 @@
 
 #![warn(missing_docs)]
 #![allow(unused_doc_comments)]
-#![feature(str_internals)]
 #![feature(untagged_unions)]
 extern crate core;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,6 @@
 //!
 
 #![warn(missing_docs)]
-#![feature(str_internals)]
 #![feature(nll)]
 extern crate core;
 


### PR DESCRIPTION
As drm-rs will probably want to target stable in the future and `str_internals` is not meant to be stabilized [at all](https://doc.rust-lang.org/unstable-book/library-features/str-internals.html), this PR gets rid of it.

The docs of Utf8Error nicely layout an [example](https://doc.rust-lang.org/nightly/core/str/struct.Utf8Error.html#examples) to implement the `Utf8Lossy::from_str` functionality ourselves. I have fitted the example to work in the only place this is currently used: for logging `SmallOsString`.