### PR TITLE
buffer format: convert from u32

### DIFF
--- a/src/buffer/format.rs
+++ b/src/buffer/format.rs
@@ -128,6 +128,70 @@ impl PixelFormat {
         }
     }
 
+    pub fn from_raw(raw: u32) -> Option<PixelFormat> {
+        use self::PixelFormat::*;
+        Some(match raw {
+           DRM_FORMAT_C8 => C8,
+           DRM_FORMAT_R8 => R8,
+           DRM_FORMAT_GR88 => GR88,
+
+           DRM_FORMAT_RGB332 => RGB332,
+           DRM_FORMAT_BGR233 => BGR233,
+
+           DRM_FORMAT_XRGB4444 => XRGB4444,
+           DRM_FORMAT_XBGR4444 => XBGR4444,
+           DRM_FORMAT_RGBX4444 => RGBX4444,
+           DRM_FORMAT_BGRX4444 => BGRX4444,
+
+           DRM_FORMAT_ARGB4444 => ARGB4444,
+           DRM_FORMAT_ABGR4444 => ABGR4444,
+           DRM_FORMAT_RGBA4444 => RGBA4444,
+           DRM_FORMAT_BGRA4444 => BGRA4444,
+
+           DRM_FORMAT_XRGB1555 => XRGB1555,
+           DRM_FORMAT_XBGR1555 => XBGR1555,
+           DRM_FORMAT_RGBX5551 => RGBX5551,
+           DRM_FORMAT_BGRX5551 => BGRX5551,
+
+           DRM_FORMAT_ARGB1555 => ARGB1555,
+           DRM_FORMAT_ABGR1555 => ABGR1555,
+           DRM_FORMAT_RGBA5551 => RGBA4444,
+           DRM_FORMAT_BGRA5551 => RGBA5551,
+
+           DRM_FORMAT_RGB565 => RGB565,
+           DRM_FORMAT_BGR565 => BGR565,
+
+           DRM_FORMAT_XRGB8888 => XRGB8888,
+           DRM_FORMAT_XBGR8888 => XBGR8888,
+           DRM_FORMAT_RGBX8888 => RGBX8888,
+           DRM_FORMAT_BGRX8888 => BGRX8888,
+
+           DRM_FORMAT_ARGB8888 => ARGB8888,
+           DRM_FORMAT_ABGR8888 => ABGR8888,
+           DRM_FORMAT_RGBA8888 => RGBA8888,
+           DRM_FORMAT_BGRA8888 => BGRA8888,
+
+           DRM_FORMAT_XRGB2101010 => XRGB2101010,
+           DRM_FORMAT_XBGR2101010 => XBGR2101010,
+           DRM_FORMAT_RGBX1010102 => RGBX1010102,
+           DRM_FORMAT_BGRX1010102 => BGRX1010102,
+
+           DRM_FORMAT_ARGB2101010 => ARGB2101010,
+           DRM_FORMAT_ABGR2101010 => ABGR2101010,
+           DRM_FORMAT_RGBA1010102 => RGBA1010102,
+           DRM_FORMAT_BGRA1010102 => BGRA1010102,
+
+           DRM_FORMAT_YUYV => YUYV,
+           DRM_FORMAT_YVYU => YVYU,
+           DRM_FORMAT_UYVY => UYVY,
+           DRM_FORMAT_VYUY => VYUY,
+
+           DRM_FORMAT_AYUV => AYUV,
+
+           _ => { return None; }
+        })
+    }
+
     /// The depth in bits per pixel.
     pub fn depth(&self) -> u32 {
         match *self {


### PR DESCRIPTION
Other way around, needed for external buffer libraries, like libgbm.