### PR TITLE
Expose ResourceHandle

### DIFF
--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -48,7 +48,6 @@ use std::mem;
 use core::num::NonZeroU32;
 pub type RawResourceHandle = NonZeroU32;
 
-#[doc(hidden)]
 pub trait ResourceHandle : From<RawResourceHandle> + Into<RawResourceHandle> + Into<u32> + Copy + Sized {
     const FFI_TYPE: u32;
 }


### PR DESCRIPTION
This is just inconvenient, especially since `ResourceHandle` is already part of the public api via `control::Device::get_properties`. 