### PR TITLE
Fixup atomic commit flags

### DIFF
--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -636,7 +636,7 @@ pub trait Device: super::Device {
 
         drm_ffi::mode::atomic_commit(
             self.as_raw_fd(),
-            flags.iter().fold(0, |acc, x| acc & *x as u32),
+            flags.iter().fold(0, |acc, x| acc | *x as u32),
             unsafe { tm(&mut *req.objects) },
             &mut *req.count_props_per_object,
             unsafe { tm(&mut *req.props) },
@@ -873,4 +873,5 @@ pub enum AtomicCommitFlags {
     TestOnly = ffi::drm_sys::DRM_MODE_ATOMIC_TEST_ONLY,
     Nonblock =  ffi::drm_sys::DRM_MODE_ATOMIC_NONBLOCK,
     AllowModeset = ffi::drm_sys::DRM_MODE_ATOMIC_ALLOW_MODESET,
+    PageFlipEvent = ffi::drm_sys::DRM_MODE_PAGE_FLIP_EVENT,
 }


### PR DESCRIPTION
This commit fixes two issues with `atomic_commit`.

1. `AtomicCommitFlags` does not allow `DRM_MODE_PAGE_FLIP_EVENT` to be used, which is also a valid atomic flag.
2. The given flags are combined using the wrong operator, resulting in wrong bitmask.

Otherwise the function is not really usable for a real compositor.