### PR TITLE
Replace failure with Display and std::error::Error.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ authors = ["Tyler Slabinski <tslabinski@slabity.net>"]
 [dependencies]
 drm-ffi = { path = "drm-ffi" }
 nix = "*"
-failure = "*"
 bitflags = "*"
 
 [dev-dependencies]

--- a/drm-ffi/Cargo.toml
+++ b/drm-ffi/Cargo.toml
@@ -9,5 +9,4 @@ authors = ["Tyler Slabinski <tslabinski@slabity.net>"]
 [dependencies]
 drm-sys = { path = "drm-sys" }
 nix = "*"
-failure = "*"
 bitflags = "*"

--- a/drm-ffi/src/lib.rs
+++ b/drm-ffi/src/lib.rs
@@ -11,8 +11,6 @@ pub extern crate drm_sys;
 pub use drm_sys::*;
 
 #[macro_use]
-extern crate failure;
-#[macro_use]
 extern crate nix;
 
 #[macro_use]


### PR DESCRIPTION
It comes with a whole bunch of dependencies which make the build slower than it should be.  On my laptop, it goes from 26.4s to 19.9s of build time for some random example.