### PR TITLE
Only enable the png feature of the image crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ failure = "*"
 bitflags = "*"
 
 [dev-dependencies]
-image = "*"
+image = { version = "*", default-features = false, features = ["png"] }
 rustyline = "*"


### PR DESCRIPTION
This disables a bunch of unused dependencies, which (after #62) make the build time on my laptop go from 19.9s to 12.4s.