### PR TITLE
get_connector/get_modes: fix mode retrieval

### DIFF
--- a/drm-ffi/src/mode.rs
+++ b/drm-ffi/src/mode.rs
@@ -324,17 +324,38 @@ pub fn get_connector(
     id: u32,
     props: Option<&mut &mut [u32]>,
     prop_values: Option<&mut &mut [u64]>,
-    modes: Option<&mut &mut [drm_mode_modeinfo]>,
+    mut modes: Option<&mut Vec<drm_mode_modeinfo>>,
     encoders: Option<&mut &mut [u32]>,
 ) -> Result<drm_mode_get_connector, Error> {
+
+    let modes_count = if modes.is_some() {
+        let mut info = drm_mode_get_connector {
+            connector_id: id,
+            ..Default::default()
+        };
+
+        unsafe {
+            ioctl::mode::get_connector(fd, &mut info)?;
+        }
+ 
+        info.count_modes
+    } else { 0 };
+ 
     let mut info = drm_mode_get_connector {
         connector_id: id,
         props_ptr: map_ptr!(&props),
         prop_values_ptr: map_ptr!(&prop_values),
-        modes_ptr: map_ptr!(&modes),
+        modes_ptr: match modes.as_mut() {
+            Some(modes) => {
+                modes.clear();
+                modes.reserve_exact(modes_count as usize);
+                modes.as_ptr() as _
+            },
+            None => 0 as _,
+        },
         encoders_ptr: map_ptr!(&encoders),
         count_props: map_len!(&props),
-        count_modes: map_len!(&modes),
+        count_modes: modes_count,
         count_encoders: map_len!(&encoders),
         ..Default::default()
     };
@@ -343,9 +364,14 @@ pub fn get_connector(
         ioctl::mode::get_connector(fd, &mut info)?;
     }
 
+    if let Some(modes) = modes {
+        unsafe {
+            modes.set_len(info.count_modes as usize);
+        }
+    }
+
     map_shrink!(props, info.count_props as usize);
     map_shrink!(prop_values, info.count_props as usize);
-    map_shrink!(modes, info.count_modes as usize);
     map_shrink!(encoders, info.count_encoders as usize);
 
     Ok(info)

--- a/src/control/connector.rs
+++ b/src/control/connector.rs
@@ -45,14 +45,14 @@ impl std::fmt::Debug for Handle {
 }
 
 /// Information about a connector
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct Info {
     pub(crate) handle: Handle,
     pub(crate) interface: Interface,
     pub(crate) interface_id: u32,
     pub(crate) connection: State,
     pub(crate) size: Option<(u32, u32)>,
-    pub(crate) modes: [control::Mode; 16],
+    pub(crate) modes: Vec<control::Mode>,
     pub(crate) encoders: [Option<control::encoder::Handle>; 3],
     pub(crate) curr_enc: Option<control::encoder::Handle>,
 }


### PR DESCRIPTION
`drm_mode_get_connector` is very picky with provided buffers and their sizes on my system.
Too small buffers for a huge list of exposed modes (like with my ultrawide monitor) just fail, leaving behind an unusable null-initialized `drm_mode_modeinfo` without throwing any errors.

Increasing the size of 16 reveals that get_modes also fails, if the buffer is too large. It expects to be called a second time with just the right buffer size. Of course we could just increase the buffer size, query the mode size, fail if it is even larger and report a smaller size on the second call. But with monitors getting bigger and bigger, any buffer size, that might appear reasonable today might be too small for the next big display tomorrow.

I have no found a reliable way to get around this with static buffers, so I opted to use a vector in this case to fix it.
Alternatively the buffer must be user-provided, if you insist on avoiding any heap-allocations.