### PR TITLE
Use stable dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,12 @@ authors = ["Tyler Slabinski <tslabinski@slabity.net>"]
 
 [dependencies]
 drm-ffi = { path = "drm-ffi" }
-drm-fourcc = "2.0"
-nix = "*"
-bitflags = "*"
+drm-fourcc = "^2.0.0"
+nix = "^0.20.0"
 
 [dev-dependencies]
-image = { version = "*", default-features = false, features = ["png"] }
-rustyline = "*"
+image = { version = "^0.23.14", default-features = false, features = ["png"] }
+rustyline = "^8.0.0"
 
 [features]
 use_bindgen = ["drm-ffi/use_bindgen"]

--- a/drm-ffi/Cargo.toml
+++ b/drm-ffi/Cargo.toml
@@ -8,8 +8,7 @@ authors = ["Tyler Slabinski <tslabinski@slabity.net>"]
 
 [dependencies]
 drm-sys = { path = "drm-sys" }
-nix = "*"
-bitflags = "*"
+nix = "^0.20.0"
 
 [features]
 use_bindgen = ["drm-sys/use_bindgen"]

--- a/drm-ffi/drm-sys/Cargo.toml
+++ b/drm-ffi/drm-sys/Cargo.toml
@@ -7,12 +7,12 @@ license = "MIT"
 build = "build.rs"
 
 [dependencies]
-libc = { version = "*", default-features = false }
+libc = { version = "^0.2.29", default-features = false }
 
 [features]
 default = []
 use_bindgen = ["bindgen", "pkg-config"]
 
 [build-dependencies]
-bindgen = { version = "*", optional = true }
-pkg-config = { version = "*", optional = true }
+bindgen = { version = "^0.57.0", optional = true }
+pkg-config = { version = "^0.3.19", optional = true }


### PR DESCRIPTION
In preparation of a first 0.4.0 release, we should switch to explicitly defined dependencies.