### PR TITLE
Add missing documentation and remove the last warnings

### DIFF
--- a/drm-ffi/src/utils.rs
+++ b/drm-ffi/src/utils.rs
@@ -36,7 +36,7 @@ pub fn shrink<T>(slice_ref: &mut &mut [T], min: usize) {
     if min < slice_ref.len() {
         let ptr = slice_ref.as_mut_ptr();
         unsafe {
-            replace(slice_ref, from_raw_parts_mut(ptr, min));
+            let _ = replace(slice_ref, from_raw_parts_mut(ptr, min));
         }
     }
 }

--- a/examples/atomic_modeset.rs
+++ b/examples/atomic_modeset.rs
@@ -10,11 +10,11 @@ use drm::Device as BasicDevice;
 use drm::buffer::DrmFourcc;
 
 use drm::control::ResourceHandle;
-use drm::control::{self, atomic, connector, crtc, dumbbuffer, framebuffer, property, AtomicCommitFlags};
+use drm::control::{self, atomic, connector, crtc, property, AtomicCommitFlags};
 
 fn find_prop_id<T: ResourceHandle>(card: &Card, handle: T, name: &'static str) -> Option<property::Handle> {
     let props = card.get_properties(handle).expect("Could not get props of connector");
-    let (ids, vals) = props.as_props_and_values();
+    let (ids, _vals) = props.as_props_and_values();
     ids.iter().find(|&id| {
         let info = card.get_property(*id).unwrap();
         info.name().to_str().map(|x| x == name).unwrap_or(false)
@@ -24,8 +24,11 @@ fn find_prop_id<T: ResourceHandle>(card: &Card, handle: T, name: &'static str) -
 pub fn main() {
     let card = Card::open_global();
 
-    card.set_client_capability(drm::ClientCapability::UniversalPlanes, true); 
-    card.set_client_capability(drm::ClientCapability::Atomic, true); 
+    card.set_client_capability(drm::ClientCapability::UniversalPlanes, true)
+        .expect("Unable to request UniversalPlanes capability"); 
+    card.set_client_capability(drm::ClientCapability::Atomic, true)
+        .expect("Unable to request Atomic capability"); 
+ 
 
     // Load the information.
     let res = card
@@ -65,7 +68,7 @@ pub fn main() {
     // Map it and grey it out.
     {
         let mut map = card.map_dumb_buffer(&mut db).expect("Could not map dumbbuffer");
-        for mut b in map.as_mut() {
+        for b in map.as_mut() {
             *b = 128;
         }
     }

--- a/examples/ffi.rs
+++ b/examples/ffi.rs
@@ -27,10 +27,6 @@ impl Card {
     fn open_global() -> Self {
         Self::open("/dev/dri/card0")
     }
-
-    fn open_control() -> Self {
-        Self::open("/dev/dri/controlD64")
-    }
 }
 
 fn print_busid(fd: RawFd) {

--- a/examples/legacy_modeset.rs
+++ b/examples/legacy_modeset.rs
@@ -5,12 +5,10 @@ mod utils;
 use utils::*;
 
 use drm::control::Device as ControlDevice;
-use drm::Device as BasicDevice;
 
 use drm::buffer::DrmFourcc;
 
-use drm::control::ResourceHandle;
-use drm::control::{connector, crtc, dumbbuffer, framebuffer};
+use drm::control::{connector, crtc};
 
 pub fn main() {
     let card = Card::open_global();
@@ -53,7 +51,7 @@ pub fn main() {
     // Map it and grey it out.
     {
         let mut map = card.map_dumb_buffer(&mut db).expect("Could not map dumbbuffer");
-        for mut b in map.as_mut() {
+        for b in map.as_mut() {
             *b = 128;
         }
     }

--- a/examples/properties.rs
+++ b/examples/properties.rs
@@ -27,7 +27,10 @@ pub fn main() {
 
     // Enable all possible client capabilities
     for &cap in capabilities::CLIENT_CAP_ENUMS {
-        card.set_client_capability(cap, true);
+        if let Err(_) = card.set_client_capability(cap, true) {
+            eprintln!("Unable to activate capability: {:?}", cap);
+            return;
+        }
     }
 
     let resources = card.resource_handles().unwrap();

--- a/examples/resources.rs
+++ b/examples/resources.rs
@@ -10,7 +10,10 @@ pub fn main() {
 
     // Enable all possible client capabilities
     for &cap in capabilities::CLIENT_CAP_ENUMS {
-        card.set_client_capability(cap, true);
+        if let Err(_) = card.set_client_capability(cap, true) {
+            eprintln!("Unable to activate capability: {:?}", cap);
+            return;
+        }
     }
 
     let resources = card.resource_handles().unwrap();
@@ -33,7 +36,7 @@ pub fn main() {
         println!("\t{:?}", info.current_encoder());
 
         for mode in card.get_modes(handle).unwrap() {
-            //println!("{:?}", mode);
+            println!("{:?}", mode);
         }
     }
     println!("\n");

--- a/examples/utils/mod.rs
+++ b/examples/utils/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 pub use drm::Device;
 pub use drm::control::Device as ControlDevice;
 
@@ -32,10 +34,6 @@ impl Card {
     pub fn open_global() -> Self {
         Self::open("/dev/dri/card0")
     }
-
-    pub fn open_control() -> Self {
-        Self::open("/dev/dri/controlD64")
-    }
 }
 
 pub mod capabilities {
@@ -66,11 +64,10 @@ pub mod capabilities {
 
 pub mod images {
     use image;
-    use image::GenericImageView;
 
     pub fn load_image(name: &str) -> image::RgbaImage {
         let path = format!("examples/images/{}", name);
-        image::open(path).unwrap().to_rgba()
+        image::open(path).unwrap().to_rgba8()
     }
 }
 

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -17,7 +17,7 @@
 //!
 //! 1. Using `Flink` to globally publish a handle using a 32-bit 'name'. This
 //! requires either holding the DRM Master lock or having the process'
-//! [AuthToken](../AuthToken.t.hmtl) authenticated. However, any process can
+//! [AuthToken](struct@crate::AuthToken) authenticated. However, any process can
 //! open these handles if they know (or even guess) the global name.
 //!
 //! 2. Converting the GEM handle into a PRIME file descriptor, and passing it

--- a/src/control/atomic.rs
+++ b/src/control/atomic.rs
@@ -1,5 +1,8 @@
+//! Helpers for atomic modesetting.
+
 use control;
 
+/// Helper struct to construct atomic commit requests
 #[derive(Debug, Clone)]
 pub struct AtomicModeReq {
     pub(super) objects: Vec<control::RawResourceHandle>,
@@ -9,6 +12,7 @@ pub struct AtomicModeReq {
 }
 
 impl AtomicModeReq {
+    /// Create a new and empty atomic commit request
     pub fn new() -> AtomicModeReq {
         AtomicModeReq {
             objects: Vec::new(),
@@ -18,6 +22,7 @@ impl AtomicModeReq {
         }
     }
 
+    /// Add a property and value pair for a given raw resource to the request
     pub fn add_raw_property(
         &mut self,
         obj_id: control::RawResourceHandle,
@@ -57,6 +62,7 @@ impl AtomicModeReq {
         }
     }
 
+    /// Add a property and value pair for a given handle to the request
     pub fn add_property<H>(
         &mut self,
         handle: H,

--- a/src/control/connector.rs
+++ b/src/control/connector.rs
@@ -91,6 +91,7 @@ impl Info {
         &self.encoders
     }
 
+    /// Returns a list of modes this connector reports as supported.
     pub fn modes(&self) ->  &[control::Mode] {
         &self.modes
     }

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -637,6 +637,8 @@ pub trait Device: super::Device {
     /// Sets a hardware-cursor on the given crtc with the image of a given buffer
     ///
     /// A buffer argument of `None` will clear the cursor.
+    #[deprecated(note = "Usage of deprecated ioctl set_cursor: use a cursor plane instead")]
+    #[allow(deprecated)]
     fn set_cursor<B>(&self, crtc: crtc::Handle, buffer: Option<&B>) -> Result<(), SystemError>
     where
         B: buffer::Buffer + ?Sized,
@@ -656,6 +658,8 @@ pub trait Device: super::Device {
     /// and a hotspot marking the click point of the cursor.
     ///
     /// A buffer argument of `None` will clear the cursor.
+    #[deprecated(note = "Usage of deprecated ioctl set_cursor2: use a cursor plane instead")]
+    #[allow(deprecated)]
     fn set_cursor2<B>(&self, crtc: crtc::Handle, buffer: Option<&B>, hotspot: (i32, i32)) -> Result<(), SystemError>
     where
         B: buffer::Buffer + ?Sized,
@@ -672,6 +676,8 @@ pub trait Device: super::Device {
     }
 
     /// Moves a set cursor on a given crtc
+    #[deprecated(note = "Usage of deprecated ioctl move_cursor: use a cursor plane instead")]
+    #[allow(deprecated)]
     fn move_cursor(&self, crtc: crtc::Handle, pos: (i32, i32)) -> Result<(), SystemError> {
         drm_ffi::mode::move_cursor(self.as_raw_fd(), crtc.into(), pos.0, pos.1)?;
 

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -386,7 +386,6 @@ pub trait Device: super::Device {
             )?;
 
         let val_len = val_slice.len();
-        let enum_len = enum_slice.len();
 
         let val_type = {
             use self::property::ValueType;

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -25,8 +25,8 @@
 //!
 //! # Usage
 //!
-//! To begin using modesetting functionality, the [Device trait](Device.t.html)
-//! must be implemented on top of the [basic Device trait](../Device.t.html).
+//! To begin using modesetting functionality, the [Device] trait
+//! must be implemented on top of the basic [super::Device] trait.
 
 use drm_ffi as ffi;
 use drm_ffi::result::SystemError;
@@ -70,7 +70,7 @@ pub fn from_u32<T: ResourceHandle>(raw: u32) -> Option<T> {
 /// This trait should be implemented by any object that acts as a DRM device and
 /// provides modesetting functionality.
 ///
-/// Like the parent [Device](../Device.t.html) trait, this crate does not
+/// Like the parent [super::Device] trait, this crate does not
 /// provide a concrete object for this trait.
 ///
 /// # Example
@@ -847,8 +847,8 @@ impl Iterator for Events {
     }
 }
 
-/// The set of [ResourceHandles](ResourceHandle.t.html) that a
-/// [Device](Device.t.html) exposes. Excluding Plane resources.
+/// The set of [ResourceHandles] that a
+/// [Device] exposes. Excluding Plane resources.
 #[derive(Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ResourceHandles {
     fbs: [Option<framebuffer::Handle>; 32],
@@ -864,25 +864,25 @@ pub struct ResourceHandles {
 }
 
 impl ResourceHandles {
-    /// Returns the set of [connector::Handles](connector/Handle.t.html)
+    /// Returns the set of [connector::Handle]
     pub fn connectors(&self) -> &[connector::Handle] {
         let buf_len = std::cmp::min(self.connectors.len(), self.conn_len);
         unsafe { mem::transmute(&self.connectors[..buf_len]) }
     }
 
-    /// Returns the set of [encoder::Handles](encoder/Handle.t.html)
+    /// Returns the set of [encoder::Handle]
     pub fn encoders(&self) -> &[encoder::Handle] {
         let buf_len = std::cmp::min(self.encoders.len(), self.enc_len);
         unsafe { mem::transmute(&self.encoders[..buf_len]) }
     }
 
-    /// Returns the set of [crtc::Handles](crtc/Handle.t.html)
+    /// Returns the set of [crtc::Handle]
     pub fn crtcs(&self) -> &[crtc::Handle] {
         let buf_len = std::cmp::min(self.crtcs.len(), self.crtc_len);
         unsafe { mem::transmute(&self.crtcs[..buf_len]) }
     }
 
-    /// Returns the set of [framebuffer::Handles](framebuffer/Handle.t.html)
+    /// Returns the set of [framebuffer::Handle]
     pub fn framebuffers(&self) -> &[framebuffer::Handle] {
         let buf_len = std::cmp::min(self.fbs.len(), self.fb_len);
         unsafe { mem::transmute(&self.fbs[..buf_len]) }
@@ -912,8 +912,8 @@ impl std::fmt::Debug for ResourceHandles {
     }
 }
 
-/// The set of [plane::Handles](plane/Handle.t.html) that a
-/// [Device](Device.t.html) exposes.
+/// The set of [plane::Handle] that a
+/// [Device] exposes.
 #[derive(Copy, Clone, Hash, PartialEq, Eq)]
 pub struct PlaneResourceHandles {
     planes: [Option<plane::Handle>; 32],
@@ -921,7 +921,7 @@ pub struct PlaneResourceHandles {
 }
 
 impl PlaneResourceHandles {
-    /// Returns the set of [plane::Handles](plane/Handle.t.html)
+    /// Returns the set of [plane::Handle]
     pub fn planes(&self) -> &[plane::Handle] {
         let buf_len = std::cmp::min(self.planes.len(), self.plane_len);
         unsafe { mem::transmute(&self.planes[..buf_len]) }
@@ -1041,7 +1041,7 @@ pub struct PropertyValueSet {
 }
 
 impl PropertyValueSet {
-    /// Returns a pair representing a set of [property::Handles](property/Handle.t.html) and their raw values
+    /// Returns a pair representing a set of [property::Handle] and their raw values
     pub fn as_props_and_values(&self) -> (&[property::Handle], &[property::RawValue]) {
         unsafe {
             mem::transmute((&self.prop_ids[..self.len], &self.prop_vals[..self.len]))

--- a/src/control/plane.rs
+++ b/src/control/plane.rs
@@ -75,6 +75,10 @@ impl Info {
         self.crtc
     }
 
+    /// Returns a filter for supported crtcs of this plane.
+    ///
+    /// Use with [ResourceHandles::filter_crtcs](../struct.ResourceHandles.html#method.filter_crtcs)
+    /// to receive a list of crtcs.
     pub fn possible_crtcs(&self) -> control::CrtcListFilter {
         control::CrtcListFilter(self.pos_crtcs)
     }

--- a/src/control/plane.rs
+++ b/src/control/plane.rs
@@ -77,7 +77,7 @@ impl Info {
 
     /// Returns a filter for supported crtcs of this plane.
     ///
-    /// Use with [ResourceHandles::filter_crtcs](../struct.ResourceHandles.html#method.filter_crtcs)
+    /// Use with [control::ResourceHandles::filter_crtcs]
     /// to receive a list of crtcs.
     pub fn possible_crtcs(&self) -> control::CrtcListFilter {
         control::CrtcListFilter(self.pos_crtcs)

--- a/src/control/property.rs
+++ b/src/control/property.rs
@@ -144,19 +144,33 @@ impl ValueType {
 /// The value of a property, in a typed format
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Value<'a> {
+    /// Unknown value
     Unknown(RawValue),
+    /// Boolean value
     Boolean(bool),
+    /// Unsigned range value
     UnsignedRange(u64),
+    /// Signed range value
     SignedRange(i64),
+    /// Enum Value
     Enum(&'a EnumValue),
+    /// Bitmask value
     Bitmask(u64),
+    /// Opaque (blob) value
     Blob(u64),
+    /// Unknown object value
     Object(Option<super::RawResourceHandle>),
+    /// Crtc object value
     CRTC(Option<super::crtc::Handle>),
+    /// Connector object value
     Connector(Option<super::connector::Handle>),
+    /// Encoder object value
     Encoder(Option<super::encoder::Handle>),
+    /// Framebuffer object value
     Framebuffer(Option<super::framebuffer::Handle>),
+    /// Plane object value
     Plane(Option<super::plane::Handle>),
+    /// Property object value
     Property(Option<Handle>),
 }
 
@@ -223,6 +237,9 @@ impl EnumValues {
         (&self.values[..self.length], &self.enums[..self.length])
     }
 
+    /// Returns an `EnumValue` for a `RawValue`
+    ///
+    /// Note: This is a dumb translation, not every RawValue is part of en Enum
     pub fn get_value_from_raw_value(&self, value: RawValue) -> &EnumValue {
         let (_, enums) = self.values();
         &enums[value as usize]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@
 //!
 //! ## Usage
 //!
-//! To begin using this crate, the [Device trait](Device.t.html) must be
-//! implemented. See the trait's [example](Device.t.html#example) section for
+//! To begin using this crate, the [Device] trait must be
+//! implemented. See the trait's [example section](trait@Device#example) for
 //! details on how to implement it.
 //!
 
@@ -114,21 +114,21 @@ pub trait Device: AsRawFd {
         Ok(())
     }
 
-    /// Generates an [AuthToken](AuthToken.t.html) for this process.
+    /// Generates an [AuthToken] for this process.
     #[deprecated(note = "Consider opening a render node instead.")]
     fn generate_auth_token(&self) -> Result<AuthToken, SystemError> {
         let token = drm_ffi::auth::get_magic_token(self.as_raw_fd())?;
         Ok(AuthToken(token.magic))
     }
 
-    /// Authenticates an [AuthToken](AuthToken.t.html) from another process.
+    /// Authenticates an [AuthToken] from another process.
     fn authenticate_auth_token(&self, token: AuthToken) -> Result<(), SystemError> {
         drm_ffi::auth::auth_magic_token(self.as_raw_fd(), token.0)?;
         Ok(())
     }
 
     /// Requests the driver to expose or hide certain capabilities. See
-    /// [ClientCapability](ClientCapability.t.html) for more information.
+    /// [ClientCapability] for more information.
     fn set_client_capability(
         &self,
         cap: ClientCapability,
@@ -138,7 +138,7 @@ pub trait Device: AsRawFd {
         Ok(())
     }
 
-    /// Gets the [BusID](BusID.t.html) of this device.
+    /// Gets the [BusID] of this device.
     fn get_bus_id(&self) -> Result<BusID, SystemError> {
         let mut buffer = [0u8; 32];
 
@@ -156,7 +156,7 @@ pub trait Device: AsRawFd {
         Ok(bus_id)
     }
 
-    /// Check to see if our [AuthToken](AuthToken.t.html) has been authenticated
+    /// Check to see if our [AuthToken] has been authenticated
     /// by the DRM Master
     fn authenticated(&self) -> Result<bool, SystemError> {
         let client = drm_ffi::get_client(self.as_raw_fd(), 0)?;


### PR DESCRIPTION
In preparation for a 0.4 release:
- cleans up the docs
- adds documentation, where missing
- removes any other left over warnings