### PR TITLE
Provide proper property blob get and create functions

### DIFF
--- a/drm-ffi/src/mode.rs
+++ b/drm-ffi/src/mode.rs
@@ -526,7 +526,7 @@ pub fn set_connector_property(
 pub fn get_property_blob(
     fd: RawFd,
     blob_id: u32,
-    data: Option<&mut &mut [u64]>,
+    data: Option<&mut &mut [u8]>,
 ) -> Result<drm_mode_get_blob, Error> {
     let mut blob = drm_mode_get_blob {
         blob_id,
@@ -544,7 +544,7 @@ pub fn get_property_blob(
 }
 
 /// Create a property blob
-pub fn create_property_blob(fd: RawFd, data: &mut [u64]) -> Result<drm_mode_create_blob, Error> {
+pub fn create_property_blob(fd: RawFd, data: &mut [u8]) -> Result<drm_mode_create_blob, Error> {
     let mut blob = drm_mode_create_blob {
         data: data.as_ptr() as _,
         length: data.len() as _,

--- a/examples/atomic_modeset.rs
+++ b/examples/atomic_modeset.rs
@@ -133,7 +133,7 @@ pub fn main() {
         property::Value::CRTC(Some(crtc.handle())),
     );
     let blob = card
-        .create_property_blob(mode)
+        .create_property_blob(&mode)
         .expect("Failed to create blob");
     atomic_req.add_property(
         crtc.handle(),

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -471,18 +471,22 @@ pub trait Device: super::Device {
         Ok(())
     }
 
-    /// Create a property blob value from a given Mode
-    fn create_property_blob(&self, mode: Mode) -> Result<property::Value<'static>, SystemError> {
-        let mut raw_mode: ffi::drm_mode_modeinfo = mode.into();
+    /// Create a property blob value from a given data blob
+    fn create_property_blob<T>(&self, data: &T) -> Result<property::Value<'static>, SystemError> {
         let data = unsafe {
-            std::slice::from_raw_parts_mut(
-                &mut raw_mode as *mut _ as *mut u64,
-                mem::size_of::<ffi::drm_mode_modeinfo>(),
-            )
+            std::slice::from_raw_parts_mut(data as *const _ as *mut u8, mem::size_of::<T>())
         };
         let blob = ffi::mode::create_property_blob(self.as_raw_fd(), data)?;
 
         Ok(property::Value::Blob(blob.blob_id.into()))
+    }
+
+    /// Get a property blob's data
+    fn get_property_blob(&self, blob: u64) -> Result<Vec<u8>, SystemError> {
+        let len = ffi::mode::get_property_blob(self.as_raw_fd(), blob as u32, None)?.length;
+        let mut data = vec![0u8; len as usize];
+        let _ = ffi::mode::get_property_blob(self.as_raw_fd(), blob as u32, Some(&mut &mut *data))?;
+        Ok(data)
     }
 
     /// Destroy a given property blob value


### PR DESCRIPTION
- Fixup `create_property_blob` so that is does not only work with `Mode` but any data.
- Provide `get_property_blob` to receive any data stored in a property blob.

I have opted for allocation here, because the size of property-blob can vary a lot and I could not estimate a reasonable upper bound. Especially EDIDs of connected monitors, which can be read in as a blob, can grow very large depending on the amount of supported modes.
`drm-ffi` provides a perfectly fine `no_std` version already anyway.