### PR TITLE
Don't implement `PlanarBuffer` for all `Buffer`s

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -111,25 +111,3 @@ pub trait PlanarBuffer {
     /// The offsets of the buffer.
     fn offsets(&self) -> [u32; 4];
 }
-
-impl<B: Buffer + ?Sized> PlanarBuffer for B {
-    fn size(&self) -> (u32, u32) {
-        Buffer::size(self)
-    }
-
-    fn format(&self) -> DrmFourcc {
-        Buffer::format(self)
-    }
-
-    fn pitches(&self) -> [u32; 4] {
-        [self.pitch(), 0, 0, 0]
-    }
-
-    fn handles(&self) -> [Option<Handle>; 4] {
-        [Some(self.handle()), None, None, None]
-    }
-
-    fn offsets(&self) -> [u32; 4] {
-        [0; 4]
-    }
-}


### PR DESCRIPTION
Because that disallows buffer Implementations, that could provide both traits,
to implement both of them, due to overlapping implementations until something
like specialization lands.