### PR TITLE
Add sub-crates as workspace members; increase CI strictness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all --all-features
+          args: --all --all-features --all-targets
 
   check-minimal:
     runs-on: ubuntu-latest
@@ -117,7 +117,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --all --all-features -Z minimal-versions
+          args: --all --all-features --all-targets -Z minimal-versions
 
   test:
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all --all-features --all-targets -- -D warnings
+          args: --all --all-features --all-targets -- -D warnings -A clippy::redundant_static_lifetimes
 
   check-minimal:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all --all-features --all-targets
+          args: --all --all-features --all-targets -- -D warnings
 
   check-minimal:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,8 @@ jobs:
         with:
           path: target
           key: ${{ runner.os }}-build-rust_nightly-check-${{ hashFiles('**/Cargo.toml') }}
-      - uses: actions-rs/clippy-check@v1
+      - name: Clippy
+        uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all --all-features
@@ -112,7 +113,8 @@ jobs:
         with:
           path: target
           key: ${{ runner.os }}-build-rust_nightly-check-minimal-${{ hashFiles('**/Cargo.toml') }}
-      - uses: actions-rs/cargo@v1
+      - name: Check
+        uses: actions-rs/cargo@v1
         with:
           command: check
           args: --all --all-features -Z minimal-versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,9 @@ rustyline = "^8.0.0"
 
 [features]
 use_bindgen = ["drm-ffi/use_bindgen"]
+
+[workspace]
+members = [
+    "drm-ffi",
+    "drm-ffi/drm-sys",
+]

--- a/drm-ffi/drm-sys/Cargo.toml
+++ b/drm-ffi/drm-sys/Cargo.toml
@@ -15,5 +15,5 @@ use_bindgen = ["bindgen", "pkg-config"]
 update_bindings = ["use_bindgen"]
 
 [build-dependencies]
-bindgen = { version = "^0.57.0", optional = true }
-pkg-config = { version = "^0.3.19", optional = true }
+bindgen = { version = "0.58", optional = true }
+pkg-config = { version = "0.3.19", optional = true }

--- a/drm-ffi/drm-sys/build.rs
+++ b/drm-ffi/drm-sys/build.rs
@@ -40,9 +40,9 @@ mod use_bindgen {
     const TMP_BIND_PREFIX: &str = "__BINDGEN_TMP_";
     const TMP_BIND_PREFIX_REG: &str = "_BINDGEN_TMP_.*";
 
-    const INCLUDES: &'static [&str] = &["drm.h", "drm_mode.h"];
+    const INCLUDES: &[&str] = &["drm.h", "drm_mode.h"];
 
-    const MACROS: &'static [&str] = &["DRM_MODE_PROP_SIGNED_RANGE", "DRM_MODE_PROP_OBJECT"];
+    const MACROS: &[&str] = &["DRM_MODE_PROP_SIGNED_RANGE", "DRM_MODE_PROP_OBJECT"];
 
     // Applies a formatting function over a slice of strings,
     // concatenating them on separate lines into a single String
@@ -118,7 +118,7 @@ mod use_bindgen {
             .generate()
             .expect("Unable to generate libdrm bindings");
 
-        let out_path = String::from(var("OUT_DIR").unwrap());
+        let out_path = var("OUT_DIR").unwrap();
         let bind_file = PathBuf::from(out_path).join("bindings.rs");
 
         bindings
@@ -130,7 +130,7 @@ mod use_bindgen {
     pub fn update_bindings() {
         use std::{fs, io::Write};
 
-        let out_path = String::from(var("OUT_DIR").unwrap());
+        let out_path = var("OUT_DIR").unwrap();
         let bind_file = PathBuf::from(out_path).join("bindings.rs");
         let dest_dir = PathBuf::from("src")
             .join("platforms")

--- a/drm-ffi/drm-sys/build.rs
+++ b/drm-ffi/drm-sys/build.rs
@@ -33,7 +33,7 @@ mod use_bindgen {
             .derive_default(true)
             .derive_hash(true)
             .derive_eq(true)
-            .whitelist_recursively(true)
+            .allowlist_recursively(true)
             .use_core()
     }
 
@@ -100,10 +100,10 @@ mod use_bindgen {
 
     pub fn generate_bindings() {
         let bindings = create_builder(&create_header())
-            .blacklist_type(TMP_BIND_PREFIX_REG)
-            .blacklist_type("drm_control_DRM_ADD_COMMAND")
-            .whitelist_type("DRM_.*|drm_.*")
-            .whitelist_var("DRM_.*|drm_.*")
+            .blocklist_type(TMP_BIND_PREFIX_REG)
+            .blocklist_type("drm_control_DRM_ADD_COMMAND")
+            .allowlist_type("DRM_.*|drm_.*")
+            .allowlist_var("DRM_.*|drm_.*")
             .constified_enum_module("drm_control_.*")
             .constified_enum_module("drm_buf_desc_.*")
             .constified_enum_module("drm_map_type")

--- a/drm-ffi/src/gem.rs
+++ b/drm-ffi/src/gem.rs
@@ -12,7 +12,7 @@ use std::os::unix::io::RawFd;
 /// Open a GEM object given it's 32-bit name, returning the handle.
 pub fn open(fd: RawFd, name: u32) -> Result<drm_gem_open, Error> {
     let mut gem = drm_gem_open {
-        name: name,
+        name,
         ..Default::default()
     };
 
@@ -25,13 +25,13 @@ pub fn open(fd: RawFd, name: u32) -> Result<drm_gem_open, Error> {
 
 /// Closes a GEM object given it's handle.
 pub fn close(fd: RawFd, handle: u32) -> Result<drm_gem_close, Error> {
-    let mut gem = drm_gem_close {
-        handle: handle,
+    let gem = drm_gem_close {
+        handle,
         ..Default::default()
     };
 
     unsafe {
-        ioctl::gem::close(fd, &mut gem)?;
+        ioctl::gem::close(fd, &gem)?;
     }
 
     Ok(gem)
@@ -40,8 +40,8 @@ pub fn close(fd: RawFd, handle: u32) -> Result<drm_gem_close, Error> {
 /// Converts a GEM object's handle to a PRIME file descriptor.
 pub fn handle_to_fd(fd: RawFd, handle: u32, flags: u32) -> Result<drm_prime_handle, Error> {
     let mut prime = drm_prime_handle {
-        handle: handle,
-        flags: flags,
+        handle,
+        flags,
         ..Default::default()
     };
 

--- a/drm-ffi/src/lib.rs
+++ b/drm-ffi/src/lib.rs
@@ -47,10 +47,10 @@ pub mod auth {
 
     /// Authorize another process' 'Magic Authentication Token'.
     pub fn auth_magic_token(fd: RawFd, auth: u32) -> Result<drm_auth, Error> {
-        let mut token = drm_auth { magic: auth };
+        let token = drm_auth { magic: auth };
 
         unsafe {
-            ioctl::auth_token(fd, &mut token)?;
+            ioctl::auth_token(fd, &token)?;
         }
 
         Ok(token)
@@ -81,8 +81,8 @@ pub mod auth {
 /// If the buffer is too big, this will coerce the buffer to the proper size.
 pub fn get_bus_id(fd: RawFd, buf: Option<&mut &mut [u8]>) -> Result<drm_unique, Error> {
     let mut busid = drm_unique {
-        unique: map_ptr!(&buf),
         unique_len: map_len!(&buf),
+        unique: map_ptr!(&buf),
     };
 
     unsafe {
@@ -118,7 +118,7 @@ pub fn get_interrupt_from_bus_id(
 /// Get client information given a client's ID.
 pub fn get_client(fd: RawFd, idx: c_int) -> Result<drm_client, Error> {
     let mut client = drm_client {
-        idx: idx,
+        idx,
         ..Default::default()
     };
 
@@ -145,13 +145,13 @@ pub fn get_capability(fd: RawFd, cty: u64) -> Result<drm_get_cap, Error> {
 
 /// Attempt to enable/disable a client's capability.
 pub fn set_capability(fd: RawFd, cty: u64, val: bool) -> Result<drm_set_client_cap, Error> {
-    let mut cap = drm_set_client_cap {
+    let cap = drm_set_client_cap {
         capability: cty,
         value: val as u64,
     };
 
     unsafe {
-        ioctl::set_cap(fd, &mut cap)?;
+        ioctl::set_cap(fd, &cap)?;
     }
 
     Ok(cap)
@@ -168,12 +168,12 @@ pub fn get_version(
     desc_buf: Option<&mut &mut [i8]>,
 ) -> Result<drm_version, Error> {
     let mut version = drm_version {
-        name: map_ptr!(&name_buf),
         name_len: map_len!(&name_buf),
-        date: map_ptr!(&date_buf),
+        name: map_ptr!(&name_buf),
         date_len: map_len!(&date_buf),
-        desc: map_ptr!(&desc_buf),
+        date: map_ptr!(&date_buf),
         desc_len: map_len!(&desc_buf),
+        desc: map_ptr!(&desc_buf),
         ..Default::default()
     };
 

--- a/drm-ffi/src/result.rs
+++ b/drm-ffi/src/result.rs
@@ -75,7 +75,7 @@ impl From<Errno> for SystemError {
             Errno::EINVAL => SystemError::InvalidArgument,
             Errno::ENOTTY => SystemError::InvalidFileDescriptor,
             Errno::EACCES => SystemError::PermissionDenied,
-            _ => SystemError::Unknown { errno: errno },
+            _ => SystemError::Unknown { errno },
         }
     }
 }

--- a/examples/kms_interactive.rs
+++ b/examples/kms_interactive.rs
@@ -11,8 +11,8 @@ pub fn main() {
 
     // Enable all possible client capabilities
     for &cap in capabilities::CLIENT_CAP_ENUMS {
-        if let Err(_) = card.set_client_capability(cap, true) {
-            eprintln!("Unable to activate capability: {:?}", cap);
+        if let Err(e) = card.set_client_capability(cap, true) {
+            eprintln!("Unable to activate capability {:?}: {}", cap, e);
             return;
         }
     }
@@ -174,6 +174,7 @@ fn run_repl(card: &Card) {
     }
 }
 
+#[allow(clippy::upper_case_acronyms)]
 enum HandleWithProperties {
     Connector(drm::control::connector::Handle),
     CRTC(drm::control::crtc::Handle),

--- a/examples/legacy_modeset.rs
+++ b/examples/legacy_modeset.rs
@@ -31,21 +31,16 @@ pub fn main() {
     // Filter each connector until we find one that's connected.
     let con = coninfo
         .iter()
-        .filter(|&i| i.state() == connector::State::Connected)
-        .next()
+        .find(|&i| i.state() == connector::State::Connected)
         .expect("No connected connectors");
 
     // Get the first (usually best) mode
-    let &mode = con
-        .modes()
-        .iter()
-        .next()
-        .expect("No modes found on connector");
+    let &mode = con.modes().get(0).expect("No modes found on connector");
 
     let (disp_width, disp_height) = mode.size();
 
     // Find a crtc and FB
-    let crtc = crtcinfo.iter().next().expect("No crtcs found");
+    let crtc = crtcinfo.get(0).expect("No crtcs found");
 
     // Select the pixel format
     let fmt = DrmFourcc::Rgba8888;

--- a/examples/properties.rs
+++ b/examples/properties.rs
@@ -18,7 +18,7 @@ fn print_properties<T: drm::control::ResourceHandle>(card: &Card, handle: T) {
         println!("Mutable: {}", info.mutable());
         println!("Atomic: {}", info.atomic());
         println!("Value: {:?}", info.value_type().convert_value(val));
-        println!("");
+        println!();
     }
 }
 
@@ -27,8 +27,8 @@ pub fn main() {
 
     // Enable all possible client capabilities
     for &cap in capabilities::CLIENT_CAP_ENUMS {
-        if let Err(_) = card.set_client_capability(cap, true) {
-            eprintln!("Unable to activate capability: {:?}", cap);
+        if let Err(e) = card.set_client_capability(cap, true) {
+            eprintln!("Unable to activate capability {:?}: {}", cap, e);
             return;
         }
     }

--- a/examples/resources.rs
+++ b/examples/resources.rs
@@ -10,8 +10,8 @@ pub fn main() {
 
     // Enable all possible client capabilities
     for &cap in capabilities::CLIENT_CAP_ENUMS {
-        if let Err(_) = card.set_client_capability(cap, true) {
-            eprintln!("Unable to activate capability: {:?}", cap);
+        if let Err(e) = card.set_client_capability(cap, true) {
+            eprintln!("Unable to activate capability {:?}: {}", cap, e);
             return;
         }
     }

--- a/src/control/encoder.rs
+++ b/src/control/encoder.rs
@@ -73,7 +73,7 @@ impl Info {
     }
 
     /// Returns a filter for the possible encoders that clones this one.
-    pub fn possible_clones(&self) -> () {
+    pub fn possible_clones(&self) {
         unimplemented!()
     }
 }

--- a/src/control/property.rs
+++ b/src/control/property.rs
@@ -84,6 +84,7 @@ impl Info {
 
 /// Describes the types of value that a property uses.
 #[allow(clippy::upper_case_acronyms)]
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum ValueType {
     /// A catch-all for any unknown types

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,6 +226,7 @@ pub trait Device: AsRawFd {
 pub struct AuthToken(u32);
 
 /// Bus ID of a device.
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct BusID(SmallOsString);
 
@@ -261,6 +262,7 @@ impl Driver {
 }
 
 /// Used to check which capabilities your graphics driver has.
+#[allow(clippy::upper_case_acronyms)]
 #[repr(u64)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum DriverCapability {


### PR DESCRIPTION
Noticed in https://github.com/Smithay/drm-rs/pull/74/files#r611252751:

Nightly clippy only runs on modules that are explicitly declared: packages directly in the root `Cargo.toml` and packages declared as workspace members.  `path=` dependencies are treated as normal dependencies (though they don't seem to be on the current 1.51 stable) and are hence not linted.

---

Without `--all-targets` only binaries and libraries are checked or linted. For completeness make sure everything - including the examples - is checked.

---

I can't consistently get `check`/`clippy` results for `build.rs` but managed to fix some warnings when it _did_ eventually run...