### PR TITLE
Release v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,9 @@
 name = "drm"
 description = "Safe, low-level bindings to the Direct Rendering Manager API"
 repository = "https://github.com/Smithay/drm-rs"
-version = "0.0.0"
+version = "0.4.0"
 license = "MIT"
-authors = ["Tyler Slabinski <tslabinski@slabity.net>"]
+authors = ["Tyler Slabinski <tslabinski@slabity.net>", "Victor Brekenfeld <crates-io@drakulix.de>"]
 exclude = [".gitignore", ".github"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # drm-rs
 
-__This library is currently a work in progress.__
-
-__A nightly compiler is required__
-
 A safe interface to the Direct Rendering Manager.
 
 ## Direct Rendering Manager
@@ -63,8 +59,17 @@ fn main() {
 
 ### Control (modesetting)
 
-**WIP** - See `drm::control::Device`
+See [`drm::control::Device`](https://docs.rs/drm/*/drm/control/trait.Device.html)
+as well as our mode-setting examples: [`atomic_modeset`](https://github.com/Smithay/drm-rs/blob/develop/examples/atomic_modeset.rs)
+and [`legacy_modeset`](https://github.com/Smithay/drm-rs/blob/develop/examples/legacy_modeset.rs)
 
 ### Rendering
 
-**WIP**
+Rendering is done by [creating](https://docs.rs/drm/*/drm/control/trait.Device.html#method.add_framebuffer) and
+[attaching](https://docs.rs/drm/*/drm/control/trait.Device.html#method.page_flip) [framebuffers](https://docs.rs/drm/*/drm/control/framebuffer/index.html)
+to [crtcs](https://docs.rs/drm/*/drm/control/crtcs/index.html).
+
+A framebuffer is created from anything implementing [`Buffer`](https://docs.rs/drm/*/drm/buffer/trait.Buffer.html) like the always
+available, but very limited, [`DumbBuffer`](https://docs.rs/drm/*/drm/control/dumbbuffer/struct.DumbBuffer.html).
+
+For faster hardware-backed buffers, checkout [gbm.rs](https://github.com/Smithay/gbm.rs).

--- a/drm-ffi/Cargo.toml
+++ b/drm-ffi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "drm-ffi"
 description = "Safe, low-level bindings to the Direct Rendering Manager API"
 repository = "https://github.com/Smithay/drm-rs"
-version = "0.0.0"
+version = "0.1.0"
 license = "MIT"
 authors = ["Tyler Slabinski <tslabinski@slabity.net>"]
 

--- a/drm-ffi/drm-sys/Cargo.toml
+++ b/drm-ffi/drm-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "drm-sys"
 description = "Bindings to the Direct Rendering Manager API"
-version = "0.0.0"
+version = "0.1.0"
 authors = ["Tyler Slabinski <tslabinski@slabity.net>"]
 license = "MIT"
 build = "build.rs"


### PR DESCRIPTION
PR to prepare a new release.

@Slabity

- I took the liberty to add myself as an author for `drm-rs` itself.
- I was not sure, what versions we want to use for `drm-ffi` and `drm-sys`, but since both can be used standalone, I opted for `0.1.0`.
- Do we want to move the develop branch into master again? I could choose a different target for this PR.

I cannot release this, because I have no publish-rights to `drm-sys`.
I would ask you to:

- Add a crates.io token as `CRATES_TOKEN` to the respository secrets, then I can merge and tag this to let github-actions publish it under your name.

*OR*

- Give me publish rights on crates.io for `drm-sys`, so I can add a token to this repository instead.



Any further thoughts on a new release can be discussed here.
I do not think we are currently missing anything crucial and the last stable release has gotten pretty old.
I have tested this branch [during smithay development](https://github.com/Smithay/smithay/pull/261) and everything seems to work fine.
Also the next gbm.rs release will depend on this version.