### PR TITLE
Update nix to 0.22 & bindgen to 0.59

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [".gitignore", ".github"]
 [dependencies]
 drm-ffi = { path = "drm-ffi", version = "0.1.0" }
 drm-fourcc = "^2.0.0"
-nix = "^0.20.0"
+nix = "^0.22.0"
 
 [dev-dependencies]
 image = { version = "^0.23.14", default-features = false, features = ["png"] }

--- a/drm-ffi/Cargo.toml
+++ b/drm-ffi/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Tyler Slabinski <tslabinski@slabity.net>"]
 
 [dependencies]
 drm-sys = { path = "drm-sys", version = "0.1.0" }
-nix = "^0.20.0"
+nix = "^0.22.0"
 
 [features]
 use_bindgen = ["drm-sys/use_bindgen"]

--- a/drm-ffi/drm-sys/Cargo.toml
+++ b/drm-ffi/drm-sys/Cargo.toml
@@ -15,5 +15,5 @@ use_bindgen = ["bindgen", "pkg-config"]
 update_bindings = ["use_bindgen"]
 
 [build-dependencies]
-bindgen = { version = "0.58", optional = true }
+bindgen = { version = "0.59", optional = true }
 pkg-config = { version = "0.3.19", optional = true }

--- a/drm-ffi/src/result.rs
+++ b/drm-ffi/src/result.rs
@@ -3,20 +3,8 @@
 //!
 
 use nix::errno::Errno;
-use nix::Error as NixError;
 use std::error::Error;
 use std::fmt;
-
-/// Errors from system calls will always be in the form [`NixError::Sys(errno)`].
-///
-/// This helper function unwraps a [`nix::Error`] into an [`Errno`] in places we
-/// know other types of errors can not occur.
-fn unwrap_errno(err: NixError) -> Errno {
-    match err {
-        NixError::Sys(errno) => errno,
-        _ => unreachable!(),
-    }
-}
 
 /// A general system error that can be returned by any DRM command.
 ///
@@ -77,11 +65,5 @@ impl From<Errno> for SystemError {
             Errno::EACCES => SystemError::PermissionDenied,
             _ => SystemError::Unknown { errno },
         }
-    }
-}
-
-impl From<NixError> for SystemError {
-    fn from(nerr: NixError) -> SystemError {
-        unwrap_errno(nerr).into()
     }
 }

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -318,7 +318,7 @@ pub trait Device: super::Device {
         handle: framebuffer::Handle,
         clips: &[ClipRect],
     ) -> Result<(), SystemError> {
-        ffi::mode::dirty_fb(self.as_raw_fd(), handle.into(), &clips)?;
+        ffi::mode::dirty_fb(self.as_raw_fd(), handle.into(), clips)?;
         Ok(())
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -40,7 +40,7 @@ impl AsRef<OsStr> for SmallOsString {
 
 impl fmt::Debug for SmallOsString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let as_os_str: &OsStr = &self.as_ref();
+        let as_os_str: &OsStr = self.as_ref();
         f.debug_struct("SmallOsString")
             .field("data", &self.data)
             .field("len", &self.len)


### PR DESCRIPTION
Note that this is a breaking change for `drm-rs` and `drm-ffi`, as `nix` is a public dependency.