### PR TITLE
drm-ffi/sys: Re-run build.rs when output files change

### DIFF
--- a/drm-ffi/drm-sys/build.rs
+++ b/drm-ffi/drm-sys/build.rs
@@ -121,6 +121,8 @@ mod use_bindgen {
         let out_path = var("OUT_DIR").unwrap();
         let bind_file = PathBuf::from(out_path).join("bindings.rs");
 
+        println!("cargo:rerun-if-changed={}", bind_file.display());
+
         bindings
             .write_to_file(bind_file)
             .expect("Could not write bindings");
@@ -137,6 +139,8 @@ mod use_bindgen {
             .join(var("CARGO_CFG_TARGET_OS").unwrap())
             .join(var("CARGO_CFG_TARGET_ARCH").unwrap());
         let dest_file = dest_dir.join("bindings.rs");
+
+        println!("cargo:rerun-if-changed={}", dest_file.display());
 
         fs::create_dir_all(&dest_dir).unwrap();
         fs::copy(&bind_file, &dest_file).unwrap();


### PR DESCRIPTION
`build.rs` does not re-run unless a clean build is performed.  To easen and solidify bindings regeneration this makes the build script re-run if the output is outdated, or doesn't exist altogether (ie.  intentionally removing the file(s) to force regeneration).  It is also documented in the [first build script example].

Theoretically the input headers (`drm.h`, `drm_mode.h` and everything recursively included) should be printed as well for consistency, but it looks like said feature has not landed in `bindgen` yet.

[first build script example]: https://doc.rust-lang.org/cargo/reference/build-scripts.html
