### PR TITLE
drm-ffi: Add getfb2 ioctl support

### DIFF
--- a/drm-ffi/src/ioctl.rs
+++ b/drm-ffi/src/ioctl.rs
@@ -125,6 +125,7 @@ pub(crate) mod mode {
 
     /// FB related functions
     ioctl_readwrite!(get_fb, DRM_IOCTL_BASE, 0xAD, drm_mode_fb_cmd);
+    ioctl_readwrite!(get_fb2, DRM_IOCTL_BASE, 0xCE, drm_mode_fb_cmd2);
     ioctl_readwrite!(add_fb, DRM_IOCTL_BASE, 0xAE, drm_mode_fb_cmd);
     ioctl_readwrite!(add_fb2, DRM_IOCTL_BASE, 0xB8, drm_mode_fb_cmd2);
     ioctl_readwrite!(rm_fb, DRM_IOCTL_BASE, 0xAF, c_uint);

--- a/drm-ffi/src/mode.rs
+++ b/drm-ffi/src/mode.rs
@@ -104,6 +104,20 @@ pub fn add_fb(
     Ok(fb)
 }
 
+/// Get info about a framebuffer (with modifiers).
+pub fn get_framebuffer2(fd: RawFd, fb_id: u32) -> Result<drm_mode_fb_cmd2, Error> {
+    let mut info = drm_mode_fb_cmd2 {
+        fb_id,
+        ..Default::default()
+    };
+
+    unsafe {
+        ioctl::mode::get_fb2(fd, &mut info)?;
+    }
+
+    Ok(info)
+}
+
 /// Add a new framebuffer (with modifiers)
 pub fn add_fb2(
     fd: RawFd,


### PR DESCRIPTION
This ioctl was added in Linux 5.7, and lets a DRM master access a previous framebuffer, no matter its format.  This can be used for smooth handoff between different DRM masters, even with modifiers, multiple planes, etc.

Edit: requires #97 to be merged for CI to complete.