### PR TITLE
Always update apt cache before install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - run: sudo apt-get install -y libdrm-dev
+      - run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libdrm-dev
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
@@ -94,7 +96,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - run: sudo apt-get install -y libdrm-dev
+      - run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libdrm-dev
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly


### PR DESCRIPTION
This prevents CI from failing intermittently.

Edit: requires #98 to be merged for CI to complete.