### PR TITLE
drm-rs: expose DRM mode flags

### DIFF
--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -1042,6 +1042,11 @@ impl Mode {
     pub fn vrefresh(&self) -> u32 {
         self.mode.vrefresh
     }
+
+    /// Returns the flags for this mode
+    pub fn flags(&self) -> u32 {
+        self.mode.flags
+    }
 }
 
 impl From<ffi::drm_mode_modeinfo> for Mode {
@@ -1067,6 +1072,7 @@ impl std::fmt::Debug for Mode {
             .field("hskew", &self.hskew())
             .field("vscan", &self.vscan())
             .field("vrefresh", &self.vrefresh())
+            .field("flags", &self.flags())
             .finish()
     }
 }


### PR DESCRIPTION
Add a function flags() to allow userspace to parse the flags for each
modeline

Signed-off-by: Aurabindo Pillai <mail@aurabindo.in>