### PR TITLE
Fix mode type flags

### DIFF
--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -1053,7 +1053,7 @@ impl Mode {
 
     /// Returns the bitmask of this mode
     pub fn mode_type(&self) -> ModeTypeFlags {
-        ModeTypeFlags::from_bits_truncate(self.mode.flags)
+        ModeTypeFlags::from_bits_truncate(self.mode.type_)
     }
 }
 


### PR DESCRIPTION
Mode type is in mode.type_, not mode.flags