### PR TITLE
connector: Don't always do implicit force probe

### DIFF
--- a/examples/atomic_modeset.rs
+++ b/examples/atomic_modeset.rs
@@ -44,7 +44,7 @@ pub fn main() {
     let coninfo: Vec<connector::Info> = res
         .connectors()
         .iter()
-        .flat_map(|con| card.get_connector(*con))
+        .flat_map(|con| card.get_connector(*con, true))
         .collect();
     let crtcinfo: Vec<crtc::Info> = res
         .crtcs()

--- a/examples/legacy_modeset.rs
+++ b/examples/legacy_modeset.rs
@@ -20,7 +20,7 @@ pub fn main() {
     let coninfo: Vec<connector::Info> = res
         .connectors()
         .iter()
-        .flat_map(|con| card.get_connector(*con))
+        .flat_map(|con| card.get_connector(*con, true))
         .collect();
     let crtcinfo: Vec<crtc::Info> = res
         .crtcs()

--- a/examples/list_modes.rs
+++ b/examples/list_modes.rs
@@ -10,7 +10,7 @@ pub fn main() {
 
     let resources = card.resource_handles().unwrap();
     for connector in resources.connectors().iter() {
-        let info = card.get_connector(*connector).unwrap();
+        let info = card.get_connector(*connector, false).unwrap();
         println!("Connector {:?}: {:?}", info.interface(), info.state());
         if info.state() == drm::control::connector::State::Connected {
             println!("\t Modes:\n{:#?}", info.modes());

--- a/examples/resources.rs
+++ b/examples/resources.rs
@@ -27,7 +27,7 @@ pub fn main() {
     println!("Planes:\t\t{:?}", plane_res.planes());
 
     for &handle in resources.connectors() {
-        let info = card.get_connector(handle).unwrap();
+        let info = card.get_connector(handle, false).unwrap();
         println!("Connector: {:?}", handle);
         println!("\t{:?}-{}", info.interface(), info.interface_id());
         println!("\t{:?}", info.state());

--- a/src/control/connector.rs
+++ b/src/control/connector.rs
@@ -51,7 +51,7 @@ pub struct Info {
     pub(crate) connection: State,
     pub(crate) size: Option<(u32, u32)>,
     pub(crate) modes: Vec<control::Mode>,
-    pub(crate) encoders: [Option<control::encoder::Handle>; 3],
+    pub(crate) encoders: Vec<control::encoder::Handle>,
     pub(crate) curr_enc: Option<control::encoder::Handle>,
 }
 
@@ -85,7 +85,7 @@ impl Info {
     }
 
     /// Returns a list of encoders that can be possibly used by this connector.
-    pub fn encoders(&self) -> &[Option<control::encoder::Handle>] {
+    pub fn encoders(&self) -> &[control::encoder::Handle] {
         &self.encoders
     }
 


### PR DESCRIPTION
The kernel docs state (as easily viewable [here](https://dri.freedesktop.org/docs/drm/gpu/drm-uapi.html#c.drm_mode_get_connector)):

> To retrieve the number of elements, set count_props and count_encoders to zero, set count_modes to 1, and set modes_ptr to a temporary [struct drm_mode_modeinfo](https://dri.freedesktop.org/docs/drm/gpu/drm-uapi.html#c.drm_mode_modeinfo) element.
>
> Performing the ioctl only twice may be racy: the number of elements may have changed with a hotplug event in-between the two ioctls. User-space is expected to retry the last ioctl until the number of elements stabilizes. The kernel won’t fill any array which doesn’t have the expected length.

> If the count_modes field is set to zero and the DRM client is the current DRM master, the kernel will perform a forced probe on the connector to refresh the connector status, modes and EDID. A forced-probe can be slow, might cause flickering and the ioctl will block.
> 
> User-space needs to force-probe connectors to ensure their metadata is up-to-date at startup and after receiving a hot-plug event. User-space may perform a forced-probe when the user explicitly requests it. User-space shouldn’t perform a forced-probe in other situations.

drm-rs currently always performs an implicit force probe (as the first ioctl call uses a mode-length of 0) *and* also does at most two ioctl calls.

This PR aims to fix both of these. `get_connector` now has a `force_probe` flag to toggle calling the function with a mode-length of 0 or 1. Additionally the second ioctl is repeated until the amount of modes is stable. This should avoid races when enumerating a new connector in reaction to a hot-plug event.
