### PR TITLE
Use dynamic allocations

### DIFF
--- a/drm-ffi/src/mode.rs
+++ b/drm-ffi/src/mode.rs
@@ -10,16 +10,24 @@ use ioctl;
 use result::SystemError as Error;
 use std::os::unix::io::RawFd;
 
-use utils;
-
 /// Enumerate most card resources.
 pub fn get_resources(
     fd: RawFd,
-    fbs: Option<&mut &mut [u32]>,
-    crtcs: Option<&mut &mut [u32]>,
-    connectors: Option<&mut &mut [u32]>,
-    encoders: Option<&mut &mut [u32]>,
+    mut fbs: Option<&mut Vec<u32>>,
+    mut crtcs: Option<&mut Vec<u32>>,
+    mut connectors: Option<&mut Vec<u32>>,
+    mut encoders: Option<&mut Vec<u32>>,
 ) -> Result<drm_mode_card_res, Error> {
+    let mut sizes = drm_mode_card_res::default();
+    unsafe {
+        ioctl::mode::get_resources(fd, &mut sizes)?;
+    }
+
+    map_reserve!(fbs, sizes.count_fbs as usize);
+    map_reserve!(crtcs, sizes.count_crtcs as usize);
+    map_reserve!(connectors, sizes.count_connectors as usize);
+    map_reserve!(encoders, sizes.count_encoders as usize);
+
     let mut res = drm_mode_card_res {
         fb_id_ptr: map_ptr!(&fbs),
         crtc_id_ptr: map_ptr!(&crtcs),
@@ -36,10 +44,10 @@ pub fn get_resources(
         ioctl::mode::get_resources(fd, &mut res)?;
     }
 
-    map_shrink!(fbs, res.count_fbs as usize);
-    map_shrink!(crtcs, res.count_crtcs as usize);
-    map_shrink!(connectors, res.count_connectors as usize);
-    map_shrink!(encoders, res.count_encoders as usize);
+    map_set!(fbs, res.count_fbs as usize);
+    map_set!(crtcs, res.count_crtcs as usize);
+    map_set!(connectors, res.count_connectors as usize);
+    map_set!(encoders, res.count_encoders as usize);
 
     Ok(res)
 }
@@ -47,18 +55,29 @@ pub fn get_resources(
 /// Enumerate plane resources.
 pub fn get_plane_resources(
     fd: RawFd,
-    planes: Option<&mut &mut [u32]>,
+    mut planes: Option<&mut Vec<u32>>,
 ) -> Result<drm_mode_get_plane_res, Error> {
+    let mut sizes = drm_mode_get_plane_res::default();
+    unsafe {
+        ioctl::mode::get_plane_resources(fd, &mut sizes)?;
+    }
+
+    if planes.is_none() {
+        return Ok(sizes);
+    }
+
+    map_reserve!(planes, sizes.count_planes as usize);
+
     let mut res = drm_mode_get_plane_res {
         plane_id_ptr: map_ptr!(&planes),
-        count_planes: map_len!(&planes),
+        count_planes: sizes.count_planes,
     };
 
     unsafe {
         ioctl::mode::get_plane_resources(fd, &mut res)?;
     }
 
-    map_shrink!(planes, res.count_planes as usize);
+    map_set!(planes, res.count_planes as usize);
 
     Ok(res)
 }
@@ -357,14 +376,37 @@ pub fn move_cursor(fd: RawFd, crtc_id: u32, x: i32, y: i32) -> Result<drm_mode_c
 pub fn get_connector(
     fd: RawFd,
     connector_id: u32,
-    props: Option<&mut &mut [u32]>,
-    prop_values: Option<&mut &mut [u64]>,
+    mut props: Option<&mut Vec<u32>>,
+    mut prop_values: Option<&mut Vec<u64>>,
     mut modes: Option<&mut Vec<drm_mode_modeinfo>>,
-    encoders: Option<&mut &mut [u32]>,
+    mut encoders: Option<&mut Vec<u32>>,
 ) -> Result<drm_mode_get_connector, Error> {
-    let modes_count = if modes.is_some() {
+    assert_eq!(props.is_some(), prop_values.is_some());
+
+    let mut sizes = drm_mode_get_connector {
+        connector_id,
+        ..Default::default()
+    };
+
+    unsafe {
+        ioctl::mode::get_connector(fd, &mut sizes)?;
+    }
+
+    let info = loop {
+        map_reserve!(props, sizes.count_props as usize);
+        map_reserve!(prop_values, sizes.count_props as usize);
+        map_reserve!(modes, sizes.count_modes as usize);
+        map_reserve!(encoders, sizes.count_encoders as usize);
+
         let mut info = drm_mode_get_connector {
             connector_id,
+            encoders_ptr: map_ptr!(&encoders),
+            modes_ptr: map_ptr!(&modes),
+            props_ptr: map_ptr!(&props),
+            prop_values_ptr: map_ptr!(&prop_values),
+            count_modes: map_len!(&modes),
+            count_props: map_len!(&props),
+            count_encoders: map_len!(&encoders),
             ..Default::default()
         };
 
@@ -372,43 +414,20 @@ pub fn get_connector(
             ioctl::mode::get_connector(fd, &mut info)?;
         }
 
-        info.count_modes
-    } else {
-        0
-    };
-
-    let mut info = drm_mode_get_connector {
-        encoders_ptr: map_ptr!(&encoders),
-        modes_ptr: match modes.as_mut() {
-            Some(modes) => {
-                modes.clear();
-                modes.reserve_exact(modes_count as usize);
-                modes.as_ptr() as _
-            }
-            None => 0u64,
-        },
-        props_ptr: map_ptr!(&props),
-        prop_values_ptr: map_ptr!(&prop_values),
-        count_modes: modes_count,
-        count_props: map_len!(&props),
-        count_encoders: map_len!(&encoders),
-        connector_id,
-        ..Default::default()
-    };
-
-    unsafe {
-        ioctl::mode::get_connector(fd, &mut info)?;
-    }
-
-    if let Some(modes) = modes {
-        unsafe {
-            modes.set_len(info.count_modes as usize);
+        if info.count_modes == sizes.count_modes
+            && info.count_encoders == sizes.count_encoders
+            && info.count_props == sizes.count_props
+        {
+            break info;
+        } else {
+            sizes = info;
         }
-    }
+    };
 
-    map_shrink!(props, info.count_props as usize);
-    map_shrink!(prop_values, info.count_props as usize);
-    map_shrink!(encoders, info.count_encoders as usize);
+    map_set!(modes, info.count_modes as usize);
+    map_set!(props, info.count_props as usize);
+    map_set!(prop_values, info.count_props as usize);
+    map_set!(encoders, info.count_encoders as usize);
 
     Ok(info)
 }
@@ -431,11 +450,26 @@ pub fn get_encoder(fd: RawFd, encoder_id: u32) -> Result<drm_mode_get_encoder, E
 pub fn get_plane(
     fd: RawFd,
     plane_id: u32,
-    formats: Option<&mut &mut [u32]>,
+    mut formats: Option<&mut Vec<u32>>,
 ) -> Result<drm_mode_get_plane, Error> {
+    let mut sizes = drm_mode_get_plane {
+        plane_id,
+        ..Default::default()
+    };
+
+    unsafe {
+        ioctl::mode::get_plane(fd, &mut sizes)?;
+    }
+
+    if formats.is_none() {
+        return Ok(sizes);
+    }
+
+    map_reserve!(formats, sizes.count_format_types as usize);
+
     let mut info = drm_mode_get_plane {
         plane_id,
-        count_format_types: map_len!(&formats),
+        count_format_types: sizes.count_format_types,
         format_type_ptr: map_ptr!(&formats),
         ..Default::default()
     };
@@ -444,7 +478,7 @@ pub fn get_plane(
         ioctl::mode::get_plane(fd, &mut info)?;
     }
 
-    map_shrink!(formats, info.count_format_types as usize);
+    map_set!(formats, info.count_format_types as usize);
 
     Ok(info)
 }
@@ -491,13 +525,25 @@ pub fn set_plane(
 pub fn get_property(
     fd: RawFd,
     prop_id: u32,
-    values: Option<&mut &mut [u64]>,
-    enums: Option<&mut &mut [drm_mode_property_enum]>,
+    mut values: Option<&mut Vec<u64>>,
+    mut enums: Option<&mut Vec<drm_mode_property_enum>>,
 ) -> Result<drm_mode_get_property, Error> {
+    let mut sizes = drm_mode_get_property {
+        prop_id,
+        ..Default::default()
+    };
+
+    unsafe {
+        ioctl::mode::get_property(fd, &mut sizes)?;
+    }
+
+    map_reserve!(values, sizes.count_values as usize);
+    map_reserve!(enums, sizes.count_enum_blobs as usize);
+
     let mut prop = drm_mode_get_property {
+        prop_id,
         values_ptr: map_ptr!(&values),
         enum_blob_ptr: map_ptr!(&enums),
-        prop_id,
         count_values: map_len!(&values),
         count_enum_blobs: map_len!(&enums),
         ..Default::default()
@@ -507,8 +553,8 @@ pub fn get_property(
         ioctl::mode::get_property(fd, &mut prop)?;
     }
 
-    map_shrink!(values, prop.count_values as usize);
-    map_shrink!(enums, prop.count_enum_blobs as usize);
+    map_set!(values, prop.count_values as usize);
+    map_set!(enums, prop.count_enum_blobs as usize);
 
     Ok(prop)
 }
@@ -537,11 +583,26 @@ pub fn set_connector_property(
 pub fn get_property_blob(
     fd: RawFd,
     blob_id: u32,
-    data: Option<&mut &mut [u8]>,
+    mut data: Option<&mut Vec<u8>>,
 ) -> Result<drm_mode_get_blob, Error> {
+    let mut sizes = drm_mode_get_blob {
+        blob_id,
+        ..Default::default()
+    };
+
+    unsafe {
+        ioctl::mode::get_blob(fd, &mut sizes)?;
+    }
+
+    if data.is_none() {
+        return Ok(sizes);
+    }
+
+    map_reserve!(data, sizes.length as usize);
+
     let mut blob = drm_mode_get_blob {
         blob_id,
-        length: map_len!(&data),
+        length: sizes.length,
         data: map_ptr!(&data),
     };
 
@@ -549,7 +610,7 @@ pub fn get_property_blob(
         ioctl::mode::get_blob(fd, &mut blob)?;
     }
 
-    map_shrink!(data, blob.length as usize);
+    map_set!(data, blob.length as usize);
 
     Ok(blob)
 }
@@ -585,9 +646,24 @@ pub fn get_properties(
     fd: RawFd,
     obj_id: u32,
     obj_type: u32,
-    props: Option<&mut &mut [u32]>,
-    values: Option<&mut &mut [u64]>,
+    mut props: Option<&mut Vec<u32>>,
+    mut values: Option<&mut Vec<u64>>,
 ) -> Result<drm_mode_obj_get_properties, Error> {
+    assert_eq!(props.is_some(), values.is_some());
+
+    let mut sizes = drm_mode_obj_get_properties {
+        obj_id,
+        obj_type,
+        ..Default::default()
+    };
+
+    unsafe {
+        ioctl::mode::obj_get_properties(fd, &mut sizes)?;
+    }
+
+    map_reserve!(props, sizes.count_props as usize);
+    map_reserve!(values, sizes.count_props as usize);
+
     let mut info = drm_mode_obj_get_properties {
         props_ptr: map_ptr!(&props),
         prop_values_ptr: map_ptr!(&values),
@@ -600,8 +676,8 @@ pub fn get_properties(
         ioctl::mode::obj_get_properties(fd, &mut info)?;
     }
 
-    map_shrink!(props, info.count_props as usize);
-    map_shrink!(values, info.count_props as usize);
+    map_set!(props, info.count_props as usize);
+    map_set!(values, info.count_props as usize);
 
     Ok(info)
 }

--- a/drm-ffi/src/mode.rs
+++ b/drm-ffi/src/mode.rs
@@ -380,11 +380,13 @@ pub fn get_connector(
     mut prop_values: Option<&mut Vec<u64>>,
     mut modes: Option<&mut Vec<drm_mode_modeinfo>>,
     mut encoders: Option<&mut Vec<u32>>,
+    force_probe: bool,
 ) -> Result<drm_mode_get_connector, Error> {
     assert_eq!(props.is_some(), prop_values.is_some());
 
     let mut sizes = drm_mode_get_connector {
         connector_id,
+        count_modes: if force_probe { 0 } else { 1 },
         ..Default::default()
     };
 

--- a/drm-ffi/src/utils.rs
+++ b/drm-ffi/src/utils.rs
@@ -1,4 +1,4 @@
-/// Takes an `Option<&mut &mut [T]>` style buffer and gets its pointer.
+/// Takes an `Option<&mut Vec<T>>` style buffer and gets its pointer.
 macro_rules! map_ptr {
     ($buffer:expr) => {
         match $buffer {
@@ -8,35 +8,31 @@ macro_rules! map_ptr {
     };
 }
 
-/// Takes an `Option<&mut &mut T>` style buffer and gets its length.
+/// Takes an `Option<&mut Vec<T>>` style buffer and gets its allocated length.
 macro_rules! map_len {
     ($buffer:expr) => {
         match $buffer {
-            Some(b) => b.len() as _,
-            None => 0 as _,
+            Some(b) => b.capacity() as _,
+            None => 0,
         }
     };
 }
 
-/// Takes an `Option<&mut &mut T>` style buffer and shrinks it.
-macro_rules! map_shrink {
-    ($buffer:expr, $min:expr) => {
+/// Takes an `Option<&mut Vec<T>>` style buffer and shrinks it.
+macro_rules! map_reserve {
+    ($buffer:expr, $size:expr) => {
         match $buffer {
-            Some(b) => utils::shrink(b, $min),
+            Some(ref mut b) => b.reserve_exact($size - b.len()),
             _ => (),
         }
     };
 }
-
-/// Takes a `&mut &mut [T]` and shrinks the slice down to a specific size.
-pub fn shrink<T>(slice_ref: &mut &mut [T], min: usize) {
-    use std::mem::replace;
-    use std::slice::from_raw_parts_mut;
-
-    if min < slice_ref.len() {
-        let ptr = slice_ref.as_mut_ptr();
-        unsafe {
-            let _ = replace(slice_ref, from_raw_parts_mut(ptr, min));
+/// Takes an `Option<&mut Vec<T>>` style buffer and shrinks it.
+macro_rules! map_set {
+    ($buffer:expr, $min:expr) => {
+        match $buffer {
+            Some(ref mut b) => unsafe { b.set_len($min) },
+            _ => (),
         }
-    }
+    };
 }

--- a/examples/atomic_modeset.rs
+++ b/examples/atomic_modeset.rs
@@ -96,7 +96,6 @@ pub fn main() {
         Vec<control::plane::Handle>,
         Vec<control::plane::Handle>,
     ) = planes
-        .planes()
         .iter()
         .filter(|&&plane| {
             card.get_plane(plane)

--- a/examples/atomic_modeset.rs
+++ b/examples/atomic_modeset.rs
@@ -44,7 +44,7 @@ pub fn main() {
     let coninfo: Vec<connector::Info> = res
         .connectors()
         .iter()
-        .flat_map(|con| card.get_connector(*con))
+        .flat_map(|con| card.get_connector(*con, true))
         .collect();
     let crtcinfo: Vec<crtc::Info> = res
         .crtcs()

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -13,7 +13,7 @@ pub fn main() {
     println!("Release Master lock: {:?}", card.release_master_lock());
 
     // Get the Bus ID of the device
-    println!("Getting Bus ID: {:?}", card.get_bus_id().unwrap().as_ref());
+    println!("Getting Bus ID: {:?}", card.get_bus_id().unwrap());
 
     // Figure out driver in use
     println!("Getting driver info");

--- a/examples/ffi.rs
+++ b/examples/ffi.rs
@@ -30,9 +30,8 @@ impl Card {
 }
 
 fn print_busid(fd: RawFd) {
-    let mut buffer = [0u8; 32];
-    let mut slice = &mut buffer[..];
-    let busid = ffi::get_bus_id(fd, Some(&mut slice));
+    let mut buffer = Vec::new();
+    let busid = ffi::get_bus_id(fd, Some(&mut buffer));
     println!("{:#?}", busid);
 }
 
@@ -42,20 +41,11 @@ fn print_client(fd: RawFd) {
 }
 
 fn print_version(fd: RawFd) {
-    let mut name = [0i8; 32];
-    let mut date = [0i8; 32];
-    let mut desc = [0i8; 32];
+    let mut name = Vec::new();
+    let mut date = Vec::new();
+    let mut desc = Vec::new();
 
-    let mut name_slice = &mut name[..];
-    let mut date_slice = &mut date[..];
-    let mut desc_slice = &mut desc[..];
-
-    let version = ffi::get_version(
-        fd,
-        Some(&mut name_slice),
-        Some(&mut date_slice),
-        Some(&mut desc_slice),
-    );
+    let version = ffi::get_version(fd, Some(&mut name), Some(&mut date), Some(&mut desc));
 
     println!("{:#?}", version);
 }

--- a/examples/kms_interactive.rs
+++ b/examples/kms_interactive.rs
@@ -92,7 +92,7 @@ fn run_repl(card: &Card) {
                 println!("\tCRTCS: {:?}", resources.crtcs());
                 println!("\tFramebuffers: {:?}", resources.framebuffers());
                 let planes = card.plane_handles().unwrap();
-                println!("\tPlanes: {:?}", planes.planes());
+                println!("\tPlanes: {:?}", planes);
             }
             // Print out the values of a specific property
             ["GetProperty", handle] => {
@@ -202,7 +202,7 @@ impl HandleWithProperties {
         }
 
         let phandles = card.plane_handles().unwrap();
-        for plane in phandles.planes().iter().map(|h| (*h).into()) {
+        for plane in phandles.iter().map(|h| (*h).into()) {
             if handle == plane {
                 return Ok(HandleWithProperties::Plane(handle.into()));
             }

--- a/examples/legacy_modeset.rs
+++ b/examples/legacy_modeset.rs
@@ -20,7 +20,7 @@ pub fn main() {
     let coninfo: Vec<connector::Info> = res
         .connectors()
         .iter()
-        .flat_map(|con| card.get_connector(*con))
+        .flat_map(|con| card.get_connector(*con, true))
         .collect();
     let crtcinfo: Vec<crtc::Info> = res
         .crtcs()

--- a/examples/list_modes.rs
+++ b/examples/list_modes.rs
@@ -10,7 +10,7 @@ pub fn main() {
 
     let resources = card.resource_handles().unwrap();
     for connector in resources.connectors().iter() {
-        let info = card.get_connector(*connector).unwrap();
+        let info = card.get_connector(*connector, false).unwrap();
         println!("Connector {:?}: {:?}", info.interface(), info.state());
         if info.state() == drm::control::connector::State::Connected {
             println!("\t Modes:\n{:#?}", info.modes());

--- a/examples/properties.rs
+++ b/examples/properties.rs
@@ -48,7 +48,7 @@ pub fn main() {
         print_properties(&card, handle);
     }
 
-    for &handle in plane_res.planes() {
+    for handle in plane_res {
         print_properties(&card, handle);
     }
 }

--- a/examples/resources.rs
+++ b/examples/resources.rs
@@ -24,7 +24,7 @@ pub fn main() {
     println!("Encoders:\t{:?}", resources.encoders());
     println!("CRTCs:\t\t{:?}", resources.crtcs());
     println!("Framebuffers:\t{:?}", resources.framebuffers());
-    println!("Planes:\t\t{:?}", plane_res.planes());
+    println!("Planes:\t\t{:?}", plane_res);
 
     for &handle in resources.connectors() {
         let info = card.get_connector(handle).unwrap();
@@ -70,7 +70,7 @@ pub fn main() {
 
     println!("\n");
 
-    for &handle in plane_res.planes() {
+    for handle in plane_res {
         let info = card.get_plane(handle).unwrap();
         println!("Plane: {:?}", handle);
         println!("\tCRTC: {:?}", info.crtc());

--- a/examples/resources.rs
+++ b/examples/resources.rs
@@ -27,7 +27,7 @@ pub fn main() {
     println!("Planes:\t\t{:?}", plane_res);
 
     for &handle in resources.connectors() {
-        let info = card.get_connector(handle).unwrap();
+        let info = card.get_connector(handle, false).unwrap();
         println!("Connector: {:?}", handle);
         println!("\t{:?}-{}", info.interface(), info.interface_id());
         println!("\t{:?}", info.state());

--- a/src/control/connector.rs
+++ b/src/control/connector.rs
@@ -51,7 +51,7 @@ pub struct Info {
     pub(crate) connection: State,
     pub(crate) size: Option<(u32, u32)>,
     pub(crate) modes: Vec<control::Mode>,
-    pub(crate) encoders: [Option<control::encoder::Handle>; 3],
+    pub(crate) encoders: Vec<control::encoder::Handle>,
     pub(crate) curr_enc: Option<control::encoder::Handle>,
 }
 
@@ -85,7 +85,7 @@ impl Info {
     }
 
     /// Returns a list of encoders that can be possibly used by this connector.
-    pub fn encoders(&self) -> &[Option<control::encoder::Handle>] {
+    pub fn encoders(&self) -> &[control::encoder::Handle] {
         &self.encoders
     }
 

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -124,7 +124,11 @@ pub trait Device: super::Device {
     }
 
     /// Returns information about a specific connector
-    fn get_connector(&self, handle: connector::Handle) -> Result<connector::Info, SystemError> {
+    fn get_connector(
+        &self,
+        handle: connector::Handle,
+        force_probe: bool,
+    ) -> Result<connector::Info, SystemError> {
         // Maximum number of encoders is 3 due to kernel restrictions
         let mut encoders = Vec::new();
         let mut modes = Vec::new();
@@ -136,6 +140,7 @@ pub trait Device: super::Device {
             None,
             Some(&mut modes),
             Some(&mut encoders),
+            force_probe,
         )?;
 
         let connector = connector::Info {
@@ -504,6 +509,7 @@ pub trait Device: super::Device {
             None,
             Some(&mut modes),
             None,
+            false,
         )?;
 
         Ok(unsafe { transmute_vec(modes) })

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -49,6 +49,7 @@ use super::util::*;
 
 use std::convert::TryFrom;
 use std::mem;
+use std::ops::RangeBounds;
 use std::os::unix::io::RawFd;
 use std::time::Duration;
 
@@ -942,6 +943,16 @@ impl ResourceHandles {
     /// Returns the set of [`framebuffer::Handle`]
     pub fn framebuffers(&self) -> &[framebuffer::Handle] {
         &self.fbs
+    }
+
+    /// Returns the supported minimum and maximum width for framebuffers
+    pub fn supported_fb_width(&self) -> impl RangeBounds<u32> {
+        self.width.0..=self.width.1
+    }
+
+    /// Returns the supported minimum and maximum height for framebuffers
+    pub fn supported_fb_height(&self) -> impl RangeBounds<u32> {
+        self.height.0..=self.height.1
     }
 
     /// Apply a filter the all crtcs of these resources, resulting in a list of crtcs allowed.

--- a/src/control/plane.rs
+++ b/src/control/plane.rs
@@ -52,14 +52,13 @@ impl std::fmt::Debug for Handle {
 }
 
 /// Information about a plane
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct Info {
     pub(crate) handle: Handle,
     pub(crate) crtc: Option<control::crtc::Handle>,
     pub(crate) fb: Option<control::framebuffer::Handle>,
     pub(crate) pos_crtcs: u32,
-    pub(crate) formats: [u32; 8],
-    pub(crate) fmt_len: usize,
+    pub(crate) formats: Vec<u32>,
 }
 
 impl Info {
@@ -88,7 +87,6 @@ impl Info {
 
     /// Returns the formats this plane supports.
     pub fn formats(&self) -> &[u32] {
-        let buf_len = std::cmp::min(self.formats.len(), self.fmt_len);
-        &self.formats[..buf_len]
+        &self.formats
     }
 }

--- a/src/control/property.rs
+++ b/src/control/property.rs
@@ -51,7 +51,7 @@ impl std::fmt::Debug for Handle {
 }
 
 /// Information about a property
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct Info {
     pub(crate) handle: Handle,
     pub(crate) val_type: ValueType,
@@ -68,7 +68,7 @@ impl Info {
 
     /// Returns the ValueType of this property.
     pub fn value_type(&self) -> ValueType {
-        self.val_type
+        self.val_type.clone()
     }
 
     /// Returns whether this property is mutable.
@@ -85,7 +85,7 @@ impl Info {
 /// Describes the types of value that a property uses.
 #[allow(clippy::upper_case_acronyms)]
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum ValueType {
     /// A catch-all for any unknown types
     Unknown,
@@ -227,17 +227,16 @@ impl std::fmt::Debug for EnumValue {
 }
 
 /// A set of [`EnumValue`]s for a single property
-#[derive(Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct EnumValues {
-    pub(crate) values: [u64; 24],
-    pub(crate) enums: [EnumValue; 24],
-    pub(crate) length: usize,
+    pub(crate) values: Vec<u64>,
+    pub(crate) enums: Vec<EnumValue>,
 }
 
 impl EnumValues {
     /// Returns a tuple containing slices to the [`RawValue`]s and the [`EnumValue`]s
     pub fn values(&self) -> (&[RawValue], &[EnumValue]) {
-        (&self.values[..self.length], &self.enums[..self.length])
+        (&self.values, &self.enums)
     }
 
     /// Returns an [`EnumValue`] for a [`RawValue`], or [`None`] if `value` is
@@ -251,16 +250,5 @@ impl EnumValues {
             values.iter().position(|&v| v == value)?
         };
         Some(&enums[index])
-    }
-}
-
-impl std::fmt::Debug for EnumValues {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let (vals, enums) = self.values();
-
-        f.debug_struct("EnumValues")
-            .field("values", &vals)
-            .field("enums", &enums)
-            .finish()
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,76 +3,8 @@
 #![allow(dead_code)]
 #![allow(missing_docs)]
 
-pub use std::ffi::OsStr;
+pub unsafe fn transmute_vec<T, U>(from: Vec<T>) -> Vec<U> {
+    let mut from = std::mem::ManuallyDrop::new(from);
 
-use std::fmt;
-
-#[derive(Copy, Clone, Hash, PartialEq, Eq)]
-pub struct SmallOsString {
-    data: [u8; 32],
-    len: usize,
-}
-
-impl SmallOsString {
-    pub fn from_u8_buffer(data: [u8; 32], len: usize) -> Self {
-        Self { data, len }
-    }
-
-    pub fn from_i8_buffer(data: [i8; 32], len: usize) -> Self {
-        unsafe { Self::from_u8_buffer(std::mem::transmute(data), len) }
-    }
-}
-
-impl AsRef<[u8]> for SmallOsString {
-    fn as_ref(&self) -> &[u8] {
-        &self.data[..self.len]
-    }
-}
-
-impl AsRef<OsStr> for SmallOsString {
-    fn as_ref(&self) -> &OsStr {
-        use std::os::unix::ffi::OsStrExt;
-
-        let slice: &[u8] = &self.data[..self.len];
-        OsStr::from_bytes(slice)
-    }
-}
-
-impl fmt::Debug for SmallOsString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let as_os_str: &OsStr = self.as_ref();
-        f.debug_struct("SmallOsString")
-            .field("data", &self.data)
-            .field("len", &self.len)
-            .field("as_ref()", &as_os_str)
-            .finish()
-    }
-}
-
-impl fmt::Display for SmallOsString {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut input = self.as_ref();
-        loop {
-            match ::std::str::from_utf8(input) {
-                Ok(valid) => {
-                    f.write_str(valid)?;
-                    break;
-                }
-                Err(error) => {
-                    let (valid, after_valid) = input.split_at(error.valid_up_to());
-                    unsafe {
-                        f.write_str(::std::str::from_utf8_unchecked(valid))?;
-                    }
-                    f.write_str("\u{FFFD}")?;
-
-                    if let Some(invalid_sequence_length) = error.error_len() {
-                        input = &after_valid[invalid_sequence_length..]
-                    } else {
-                        break;
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
+    Vec::from_raw_parts(from.as_mut_ptr() as *mut U, from.len(), from.capacity())
 }


### PR DESCRIPTION
After the discussion in #121 we concluded, that the current approach of using fixed length static slices for querying dynamic resources inside drm-rs is suboptimal and error-prone.

Commit 1 replaces all questionable uses of this pattern with `Vec`s. This results in some code being simplified.

Commit 2 is just exposing to variables we always queried, but were never readable by the user.

Commit 3 supersedes #121 by fixing the original issue described in there.

@Slabity A review on the first commit would be nice, given the amount of changes. I am feeling fairly certain with the rest.