### PR TITLE
Also use add_fb2 for packed buffers. Allows to pass pixel_format.

### DIFF
--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -266,21 +266,23 @@ pub trait Device: super::Device {
     fn add_framebuffer<B>(
         &self,
         buffer: &B,
-        depth: u32,
-        bpp: u32,
+        modifier: Option<DrmModifier>,
+        flags: u32,
     ) -> Result<framebuffer::Handle, SystemError>
     where
         B: buffer::Buffer + ?Sized,
     {
         let (w, h) = buffer.size();
-        let info = ffi::mode::add_fb(
+        let info = ffi::mode::add_fb2(
             self.as_raw_fd(),
             w,
             h,
-            buffer.pitch(),
-            bpp,
-            depth,
-            buffer.handle().into(),
+            buffer.format() as u32,
+            &[buffer.handle().into(), 0,0,0],
+            &[buffer.pitch(),0,0,0],
+            &[0,0,0,0],
+            &[modifier.map(Into::<u64>::into).unwrap_or(0),0,0,0],
+            flags,
         )?;
 
         Ok(from_u32(info.fb_id).unwrap())


### PR DESCRIPTION
Hello,
I'm experimenting with getting 10bit HDR passthrough on my laptop.
It looks like I needed to use add_fb2 to get the 10bit pixel format through.
This patch makes sense to me, but I'm a newbie to this so your mileage may vary.
Cheers