### PR TITLE
Ergonomics: Expose the `ClipRect` type used by `dirty_framebuffer`

### DIFF
--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -1168,7 +1168,8 @@ impl PropertyValueSet {
     }
 }
 
-type ClipRect = ffi::drm_sys::drm_clip_rect;
+/// Describes a rectangular region of a buffer
+pub type ClipRect = ffi::drm_sys::drm_clip_rect;
 
 bitflags::bitflags! {
     /// Commit flags for atomic mode setting


### PR DESCRIPTION
Hi, 

This is just a tiny fix for an ergonomics issue I encountered today.

The `dirty_framebuffer` function takes a slice of `ClipRect`s (alias of `drm_clip_rect`), however this type is private and not exposed by the `drm` crate.
This means to use `dirty_framebuffer`, applications need to pull in the `drm-ffi` crate and use `drm_clip_rect` directly from there. Doing that feels a little janky.

This pull request simply exposes the `ClipRect` type by making it `pub`, and adds a doc comment to make the linter happy.

Cheers!

jbit