### PR TITLE
deps: Update nix to 0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ drm-ffi = { path = "drm-ffi", version = "0.3.0" }
 drm-fourcc = "^2.2.0"
 
 [dependencies.nix]
-version = "0.24.1"
+version = "0.25.0"
 default-features = false
 features = ["mman"]
 

--- a/drm-ffi/Cargo.toml
+++ b/drm-ffi/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Tyler Slabinski <tslabinski@slabity.net>"]
 drm-sys = { path = "drm-sys", version = "0.2.0" }
 
 [dependencies.nix]
-version = "0.24.1"
+version = "0.25.0"
 default-features = false
 features = ["ioctl"]
 


### PR DESCRIPTION
Given #132 needs to be released as a new version anyway, lets bump our other dependencies major versions as well.
This will also get rid of the open and stale #129 PR.