### PR TITLE
Set a MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Rust
@@ -35,7 +35,7 @@ jobs:
           args: --all -- --check
 
   doc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Rust
@@ -61,7 +61,7 @@ jobs:
           command: doc
 
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v1
       - run: |
@@ -93,7 +93,7 @@ jobs:
           args: --all --all-features --all-targets -- -D warnings -A clippy::redundant_static_lifetimes
 
   check-minimal:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v1
       - run: |
@@ -134,36 +134,36 @@ jobs:
         include:
           # Generate bindings
           - task: bindings
-            os: ubuntu-latest
+            os: ubuntu-22.04
             rust: stable
             target: i686-unknown-linux-gnu
           - task: bindings
-            os: ubuntu-latest
+            os: ubuntu-22.04
             rust: stable
             target: x86_64-unknown-linux-gnu
           - task: bindings
-            os: ubuntu-latest
+            os: ubuntu-22.04
             rust: stable
             target: arm-unknown-linux-gnueabihf
           - task: bindings
-            os: ubuntu-latest
+            os: ubuntu-22.04
             rust: stable
             target: armv7-unknown-linux-gnueabihf
           - task: bindings
-            os: ubuntu-latest
+            os: ubuntu-22.04
             rust: stable
             target: aarch64-unknown-linux-gnu
           # Test channels
           - task: channels
-            os: ubuntu-latest
+            os: ubuntu-22.04
             rust: stable
             target: x86_64-unknown-linux-gnu
           - task: channels
-            os: ubuntu-latest
+            os: ubuntu-22.04
             rust: beta
             target: x86_64-unknown-linux-gnu
           - task: channels
-            os: ubuntu-latest
+            os: ubuntu-22.04
             rust: nightly
             target: x86_64-unknown-linux-gnu
     runs-on: ${{ matrix.os }}
@@ -189,12 +189,12 @@ jobs:
           case "${{ matrix.target }}" in
             arm* | aarch64*)
           sudo tee /etc/apt/sources.list << EOF
-          deb [arch=i386,amd64] http://archive.ubuntu.com/ubuntu/ focal main universe
-          deb [arch=i386,amd64] http://archive.ubuntu.com/ubuntu/ focal-updates main universe
-          deb [arch=i386,amd64] http://security.ubuntu.com/ubuntu/ focal-security main universe
-          deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal main universe
-          deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-updates main universe
-          deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-security main universe
+          deb [arch=i386,amd64] http://archive.ubuntu.com/ubuntu/ jammy main universe
+          deb [arch=i386,amd64] http://archive.ubuntu.com/ubuntu/ jammy-updates main universe
+          deb [arch=i386,amd64] http://security.ubuntu.com/ubuntu/ jammy-security main universe
+          deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main universe
+          deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main universe
+          deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-security main universe
           EOF
               ;;
           esac
@@ -202,7 +202,7 @@ jobs:
           dpkg --print-foreign-architectures
           sudo apt-get update -y
           sudo apt-get upgrade -y --fix-broken
-          sudo apt-get install -y libdrm-dev:${SYSTEM_ARCH} gcc-${GCC_TARGET} pkg-config-${GCC_TARGET}
+          sudo apt-get install -y libdrm-dev:${SYSTEM_ARCH} gcc-${GCC_TARGET} pkg-config
           echo "CARGO_TARGET_${ENV_TARGET_UC}_LINKER=${GCC_TARGET}-gcc" >> $GITHUB_ENV
           echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
           echo "PKG_CONFIG_${ENV_TARGET}=${GCC_TARGET}-pkg-config" >> $GITHUB_ENV
@@ -268,7 +268,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' && !startsWith(github.ref, 'refs/tags/') }}
     needs:
       - test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Download bindings
@@ -294,7 +294,7 @@ jobs:
       - check
       - check-minimal
       - test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           profile: minimal
           components: rust-docs
           default: true
@@ -69,7 +69,7 @@ jobs:
           sudo apt-get install -y libdrm-dev
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: 1.63.0
           profile: minimal
           components: clippy
           default: true
@@ -80,12 +80,12 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ runner.os }}-cargo-rust_nightly-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-rust_1.63.0-${{ hashFiles('**/Cargo.toml') }}
       - name: Build cache
         uses: actions/cache@v2
         with:
           path: target
-          key: ${{ runner.os }}-build-rust_nightly-check-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-build-rust_1.63.0-check-${{ hashFiles('**/Cargo.toml') }}
       - name: Clippy
         uses: actions-rs/clippy-check@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.7.0"
 license = "MIT"
 authors = ["Tyler Slabinski <tslabinski@slabity.net>", "Victoria Brekenfeld <crates-io@drakulix.de>"]
 exclude = [".gitignore", ".github"]
+rust-version = "1.63"
 
 [dependencies]
 bitflags = "1"

--- a/drm-ffi/Cargo.toml
+++ b/drm-ffi/Cargo.toml
@@ -5,6 +5,7 @@ repository = "https://github.com/Smithay/drm-rs"
 version = "0.3.0"
 license = "MIT"
 authors = ["Tyler Slabinski <tslabinski@slabity.net>"]
+rust-version = "1.63"
 
 [dependencies]
 drm-sys = { path = "drm-sys", version = "0.2.0" }

--- a/drm-ffi/drm-sys/Cargo.toml
+++ b/drm-ffi/drm-sys/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.2.0"
 authors = ["Tyler Slabinski <tslabinski@slabity.net>"]
 license = "MIT"
 build = "build.rs"
+rust-version = "1.63"
 
 [dependencies]
 libc = { version = "^0.2.29", default-features = false }

--- a/drm-ffi/src/mode.rs
+++ b/drm-ffi/src/mode.rs
@@ -373,7 +373,6 @@ pub fn move_cursor(fd: RawFd, crtc_id: u32, x: i32, y: i32) -> Result<drm_mode_c
 }
 
 /// Get info about a connector
-#[allow(clippy::bool_to_int_with_if)]
 pub fn get_connector(
     fd: RawFd,
     connector_id: u32,


### PR DESCRIPTION
We have had several discussions about a MSRV and version bumbs without writing it down. This PR addresses that and uses 1.63, which is the minimum supported rust version of our newest dependency `nix`. (Which is also part of the public api through our `SystemError`-type, so this needs a major version bumb for a release anyway.)

clippy currently runs as nightly, which means any new lints will be immediately picked up.
Even ones that suggest code, that might not be compatible with out MSRV, so that CI-job is now also pinned.
This means we even have to revert a lint-allow that was previously set.
