### PR TITLE
Remove BusID link from documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@ pub trait Device: AsFd {
         Ok(())
     }
 
-    /// Gets the [`BusID`] of this device.
+    /// Gets the bus ID of this device.
     fn get_bus_id(&self) -> Result<OsString, SystemError> {
         let mut buffer = Vec::new();
         let _ = drm_ffi::get_bus_id(self.as_fd().as_raw_fd(), Some(&mut buffer))?;


### PR DESCRIPTION
A while ago we removed the `BusID` object and replaced it with a simple `OsString`. The link in the documentation was never removed for the `get_bus_id` function.

This removes the invalid link in the documentation and should stop that CI warning that appears on every PR