### PR TITLE
Add connector subpixel getter

### DIFF
--- a/src/control/connector.rs
+++ b/src/control/connector.rs
@@ -260,6 +260,7 @@ impl From<State> for u32 {
 }
 
 /// Subpixel order of the connected sink
+#[non_exhaustive]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum SubPixel {
     /// Unknown geometry

--- a/src/control/connector.rs
+++ b/src/control/connector.rs
@@ -292,19 +292,3 @@ impl From<u32> for SubPixel {
         }
     }
 }
-
-impl From<SubPixel> for u32 {
-    fn from(state: SubPixel) -> Self {
-        // These values are not defined in drm_mode.h
-        // They were copied from linux's drm_connector.h
-        // Don't mistake those for ones used in xf86DrmMode.h (libdrm offsets those by 1)
-        match state {
-            SubPixel::Unknown => 0,
-            SubPixel::HorizontalRgb => 1,
-            SubPixel::HorizontalBgr => 2,
-            SubPixel::VerticalRgb => 3,
-            SubPixel::VerticalBgr => 4,
-            SubPixel::None => 5,
-        }
-    }
-}

--- a/src/control/connector.rs
+++ b/src/control/connector.rs
@@ -275,6 +275,8 @@ pub enum SubPixel {
     VerticalBgr,
     /// No geometry
     None,
+    /// Encountered value not supported by drm-rs
+    NotImplemented,
 }
 
 impl SubPixel {
@@ -289,7 +291,7 @@ impl SubPixel {
             3 => Self::VerticalRgb,
             4 => Self::VerticalBgr,
             5 => Self::None,
-            _ => Self::Unknown,
+            _ => Self::NotImplemented,
         }
     }
 }

--- a/src/control/connector.rs
+++ b/src/control/connector.rs
@@ -57,6 +57,7 @@ pub struct Info {
     pub(crate) modes: Vec<control::Mode>,
     pub(crate) encoders: Vec<control::encoder::Handle>,
     pub(crate) curr_enc: Option<control::encoder::Handle>,
+    pub(crate) subpixel: SubPixel,
 }
 
 impl Info {
@@ -101,6 +102,11 @@ impl Info {
     /// Returns the current encoder attached to this connector.
     pub fn current_encoder(&self) -> Option<control::encoder::Handle> {
         self.curr_enc
+    }
+
+    /// Subpixel order of the connected sink
+    pub fn subpixel(&self) -> SubPixel {
+        self.subpixel
     }
 }
 
@@ -249,6 +255,56 @@ impl From<State> for u32 {
             State::Connected => 1,
             State::Disconnected => 2,
             State::Unknown => 3,
+        }
+    }
+}
+
+/// Subpixel order of the connected sink
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum SubPixel {
+    /// Unknown geometry
+    Unknown,
+    /// Horizontal RGB
+    HorizontalRgb,
+    /// Horizontal BGR
+    HorizontalBgr,
+    /// Vertical RGB
+    VerticalRgb,
+    /// Vertical BGR
+    VerticalBgr,
+    /// No geometry
+    None,
+}
+
+impl From<u32> for SubPixel {
+    fn from(n: u32) -> Self {
+        // These values are not defined in drm_mode.h
+        // They were copied from linux's drm_connector.h
+        // Don't mistake those for ones used in xf86DrmMode.h (libdrm offsets those by 1)
+        match n {
+            0 => Self::Unknown,
+            1 => Self::HorizontalRgb,
+            2 => Self::HorizontalBgr,
+            3 => Self::VerticalRgb,
+            4 => Self::VerticalBgr,
+            5 => Self::None,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+impl From<SubPixel> for u32 {
+    fn from(state: SubPixel) -> Self {
+        // These values are not defined in drm_mode.h
+        // They were copied from linux's drm_connector.h
+        // Don't mistake those for ones used in xf86DrmMode.h (libdrm offsets those by 1)
+        match state {
+            SubPixel::Unknown => 0,
+            SubPixel::HorizontalRgb => 1,
+            SubPixel::HorizontalBgr => 2,
+            SubPixel::VerticalRgb => 3,
+            SubPixel::VerticalBgr => 4,
+            SubPixel::None => 5,
         }
     }
 }

--- a/src/control/connector.rs
+++ b/src/control/connector.rs
@@ -277,8 +277,8 @@ pub enum SubPixel {
     None,
 }
 
-impl From<u32> for SubPixel {
-    fn from(n: u32) -> Self {
+impl SubPixel {
+    pub(super) fn from_raw(n: u32) -> Self {
         // These values are not defined in drm_mode.h
         // They were copied from linux's drm_connector.h
         // Don't mistake those for ones used in xf86DrmMode.h (libdrm offsets those by 1)

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -170,7 +170,7 @@ pub trait Device: super::Device {
             modes: Mode::wrap_vec(modes),
             encoders: unsafe { transmute_vec_from_u32(encoders) },
             curr_enc: unsafe { mem::transmute(ffi_info.encoder_id) },
-            subpixel: connector::SubPixel::from(ffi_info.subpixel),
+            subpixel: connector::SubPixel::from_raw(ffi_info.subpixel),
         };
 
         Ok(connector)

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -170,6 +170,7 @@ pub trait Device: super::Device {
             modes: Mode::wrap_vec(modes),
             encoders: unsafe { transmute_vec_from_u32(encoders) },
             curr_enc: unsafe { mem::transmute(ffi_info.encoder_id) },
+            subpixel: connector::SubPixel::from(ffi_info.subpixel),
         };
 
         Ok(connector)


### PR DESCRIPTION
Enum definition on kernel side: https://github.com/torvalds/linux/blob/76f598ba7d8e2bfb4855b5298caedd5af0c374a8/include/drm/drm_connector.h#L136

libdrm [offsets this enum by 1](https://gitlab.freedesktop.org/mesa/drm/-/blob/main/xf86drmMode.c#L570) that's why in [xf86DrmMode.h](https://gitlab.freedesktop.org/mesa/drm/-/blob/main/xf86drmMode.h#L196) the values are different.