### PR TITLE
link to libdrm in drm-sys

### DIFF
--- a/drm-ffi/drm-sys/build.rs
+++ b/drm-ffi/drm-sys/build.rs
@@ -188,4 +188,6 @@ pub fn main() {
             target_os, target_arch
         );
     }
+
+    println!("cargo:rustc-link-lib=drm");
 }


### PR DESCRIPTION
It seems to be typical for `-sys` crates to link to the library they generate bindings for. 

sources: 
https://github.com/alexcrichton/curl-rust/blob/main/curl-sys/build.rs#L530
https://github.com/zmwangx/rust-ffmpeg-sys/blob/master/build.rs#L635

I can also use pkg_config if that's preferred, but currently that's behind a feature flag so I figured I'd keep it that way, plus any sane configuration should have libdrm in default search paths...right....?