### PR TITLE
Add AsRef impl for DumbMapping

### DIFF
--- a/src/control/dumbbuffer.rs
+++ b/src/control/dumbbuffer.rs
@@ -6,6 +6,9 @@
 
 use buffer;
 
+use std::borrow::{Borrow, BorrowMut};
+use std::ops::{Deref, DerefMut};
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 /// Slow, but generic [`buffer::Buffer`] implementation
 pub struct DumbBuffer {
@@ -28,8 +31,34 @@ impl AsRef<[u8]> for DumbMapping<'_> {
     }
 }
 
-impl<'a> AsMut<[u8]> for DumbMapping<'a> {
+impl AsMut<[u8]> for DumbMapping<'_> {
     fn as_mut(&mut self) -> &mut [u8] {
+        self.map
+    }
+}
+
+impl Borrow<[u8]> for DumbMapping<'_> {
+    fn borrow(&self) -> &[u8] {
+        self.map
+    }
+}
+
+impl BorrowMut<[u8]> for DumbMapping<'_> {
+    fn borrow_mut(&mut self) -> &mut [u8] {
+        self.map
+    }
+}
+
+impl Deref for DumbMapping<'_> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.map
+    }
+}
+
+impl DerefMut for DumbMapping<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
         self.map
     }
 }

--- a/src/control/dumbbuffer.rs
+++ b/src/control/dumbbuffer.rs
@@ -22,6 +22,12 @@ pub struct DumbMapping<'a> {
     pub(crate) map: &'a mut [u8],
 }
 
+impl AsRef<[u8]> for DumbMapping<'_> {
+    fn as_ref(&self) -> &[u8] {
+        self.map
+    }
+}
+
 impl<'a> AsMut<[u8]> for DumbMapping<'a> {
     fn as_mut(&mut self) -> &mut [u8] {
         self.map


### PR DESCRIPTION
In softbuffer's DRM implementation, we need to have a way to get a [u8] slice for our Deref implementation. Right now, we just create an entire buffer of zeroes and read from that. As that is unidiomatic, this PR adds an AsRef impl to DumbMapping to get a reference to the underlying memory.

See:
https://github.com/rust-windowing/softbuffer/pull/135#discussion_r1288807990