### PR TITLE
Fix clippy warnings

### DIFF
--- a/drm-ffi/src/mode.rs
+++ b/drm-ffi/src/mode.rs
@@ -255,9 +255,9 @@ pub fn get_gamma(
     let mut lut = drm_mode_crtc_lut {
         crtc_id,
         gamma_size: size as _,
-        red: red.as_ptr() as _,
-        green: green.as_ptr() as _,
-        blue: blue.as_ptr() as _,
+        red: red.as_mut_ptr() as _,
+        green: green.as_mut_ptr() as _,
+        blue: blue.as_mut_ptr() as _,
     };
 
     unsafe {
@@ -409,8 +409,8 @@ pub fn get_connector(
         let mut info = drm_mode_get_connector {
             connector_id,
             encoders_ptr: map_ptr!(&encoders),
-            modes_ptr: match &modes {
-                Some(b) => b.as_ptr() as _,
+            modes_ptr: match &mut modes {
+                Some(b) => b.as_mut_ptr() as _,
                 None => {
                     if force_probe {
                         0 as _
@@ -644,7 +644,7 @@ pub fn get_property_blob(
 /// Create a property blob
 pub fn create_property_blob(fd: RawFd, data: &mut [u8]) -> Result<drm_mode_create_blob, Error> {
     let mut blob = drm_mode_create_blob {
-        data: data.as_ptr() as _,
+        data: data.as_mut_ptr() as _,
         length: data.len() as _,
         ..Default::default()
     };
@@ -766,10 +766,10 @@ pub fn atomic_commit(
     let mut atomic = drm_mode_atomic {
         flags,
         count_objs: objs.len() as _,
-        objs_ptr: objs.as_ptr() as _,
-        count_props_ptr: prop_counts.as_ptr() as _,
-        props_ptr: props.as_ptr() as _,
-        prop_values_ptr: values.as_ptr() as _,
+        objs_ptr: objs.as_mut_ptr() as _,
+        count_props_ptr: prop_counts.as_mut_ptr() as _,
+        props_ptr: props.as_mut_ptr() as _,
+        prop_values_ptr: values.as_mut_ptr() as _,
         ..Default::default()
     };
 

--- a/drm-ffi/src/syncobj.rs
+++ b/drm-ffi/src/syncobj.rs
@@ -199,7 +199,7 @@ pub fn query(
 
     let mut args = drm_syncobj_timeline_array {
         handles: handles.as_ptr() as _,
-        points: points.as_ptr() as _,
+        points: points.as_mut_ptr() as _,
         count_handles: handles.len() as _,
         flags: if last_submitted {
             DRM_SYNCOBJ_QUERY_FLAGS_LAST_SUBMITTED

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -1349,7 +1349,7 @@ impl IntoIterator for PropertyValueSet {
         Zip<std::vec::IntoIter<property::Handle>, std::vec::IntoIter<property::RawValue>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.prop_ids.into_iter().zip(self.prop_vals.into_iter())
+        self.prop_ids.into_iter().zip(self.prop_vals)
     }
 }
 


### PR DESCRIPTION
We were using `.as_ptr()` on `&mut` parameters, but `.as_mut_ptr()` makes more sense semantically here, despite it ending up as a `u64` in some kernel struct.