### PR TITLE
Make add_planar_framebuffer() take only one modifier

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -109,6 +109,8 @@ pub trait PlanarBuffer {
     fn size(&self) -> (u32, u32);
     /// The format of the buffer.
     fn format(&self) -> DrmFourcc;
+    /// The modifier of the buffer.
+    fn modifier(&self) -> Option<DrmModifier>;
     /// The pitches of the buffer.
     fn pitches(&self) -> [u32; 4];
     /// The handles to the buffer.

--- a/src/control/framebuffer.rs
+++ b/src/control/framebuffer.rs
@@ -97,7 +97,7 @@ pub struct PlanarInfo {
     pub(crate) buffers: [Option<buffer::Handle>; 4],
     pub(crate) pitches: [u32; 4],
     pub(crate) offsets: [u32; 4],
-    pub(crate) modifier: [DrmModifier; 4],
+    pub(crate) modifier: Option<DrmModifier>,
 }
 
 impl PlanarInfo {
@@ -137,7 +137,7 @@ impl PlanarInfo {
     }
 
     /// Returns the modifier of this framebuffer.
-    pub fn modifier(&self) -> [DrmModifier; 4] {
+    pub fn modifier(&self) -> Option<DrmModifier> {
         self.modifier
     }
 }

--- a/src/control/framebuffer.rs
+++ b/src/control/framebuffer.rs
@@ -93,7 +93,7 @@ pub struct PlanarInfo {
     pub(crate) handle: Handle,
     pub(crate) size: (u32, u32),
     pub(crate) pixel_format: DrmFourcc,
-    pub(crate) flags: u32,
+    pub(crate) flags: control::FbCmd2Flags,
     pub(crate) buffers: [Option<buffer::Handle>; 4],
     pub(crate) pitches: [u32; 4],
     pub(crate) offsets: [u32; 4],
@@ -117,7 +117,7 @@ impl PlanarInfo {
     }
 
     /// Returns the flags of this framebuffer.
-    pub fn flags(&self) -> u32 {
+    pub fn flags(&self) -> control::FbCmd2Flags {
         self.flags
     }
 

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -263,6 +263,9 @@ pub trait Device: super::Device {
         };
 
         let flags = FbCmd2Flags::from_bits_truncate(info.flags);
+        let modifier = flags
+            .contains(FbCmd2Flags::MODIFIERS)
+            .then(|| DrmModifier::from(info.modifier[0]));
 
         let fb = framebuffer::PlanarInfo {
             handle,
@@ -272,7 +275,7 @@ pub trait Device: super::Device {
             buffers: bytemuck::cast(info.handles),
             pitches: info.pitches,
             offsets: info.offsets,
-            modifier: info.modifier.map(DrmModifier::from),
+            modifier,
         };
 
         Ok(fb)


### PR DESCRIPTION
The kernel enforces all four modifiers to actually be the same, so requesting four of them is a legacy artifact by now.  Let’s avoid encoding such legacy into our APIs even more.

Additionally, making `None` default to `LINEAR` doesn’t seem very valid, if there was a default to pick I think it would be `INVALID`, but it is actually much better to ask the user which modifier they actually want.