### PR TITLE
Simplify iteration on properties in examples

### DIFF
--- a/examples/atomic_modeset.rs
+++ b/examples/atomic_modeset.rs
@@ -107,8 +107,7 @@ pub fn main() {
         })
         .partition(|&&plane| {
             if let Ok(props) = card.get_properties(plane) {
-                let (ids, vals) = props.as_props_and_values();
-                for (&id, &val) in ids.iter().zip(vals.iter()) {
+                for (&id, &val) in props.iter() {
                     if let Ok(info) = card.get_property(id) {
                         if info.name().to_str().map(|x| x == "type").unwrap_or(false) {
                             return val == (drm::control::PlaneType::Primary as u32).into();

--- a/examples/kms_interactive.rs
+++ b/examples/kms_interactive.rs
@@ -115,8 +115,7 @@ fn run_repl(card: &Card) {
                         HandleWithProperties::CRTC(handle) => card.get_properties(handle).unwrap(),
                         HandleWithProperties::Plane(handle) => card.get_properties(handle).unwrap(),
                     };
-                    let (ids, vals) = props.as_props_and_values();
-                    for (id, val) in ids.iter().zip(vals.iter()) {
+                    for (id, val) in props.iter() {
                         println!("\tProperty: {:?}\tValue: {:?}", id, val);
                     }
                 }

--- a/examples/properties.rs
+++ b/examples/properties.rs
@@ -8,9 +8,7 @@ use utils::*;
 fn print_properties<T: drm::control::ResourceHandle>(card: &Card, handle: T) {
     let props = card.get_properties(handle).unwrap();
 
-    let (ids, vals) = props.as_props_and_values();
-
-    for (&id, &val) in ids.iter().zip(vals.iter()) {
+    for (&id, &val) in props.iter() {
         println!("Property: {:?}", id);
         let info = card.get_property(id).unwrap();
         println!("{:?}", info.name());


### PR DESCRIPTION
This exists since 3ba317c2d4f61dad370849c5e4b5ce46ba167203 and should be used in examples to show the simpler API.