### PR TITLE
Reduce the number of get_property ioctls called

### DIFF
--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -50,6 +50,7 @@ use buffer;
 
 use super::util::*;
 
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::iter::Zip;
 use std::mem;
@@ -1427,6 +1428,20 @@ pub struct PropertyValueSet {
 }
 
 impl PropertyValueSet {
+    /// Returns a HashMap mapping property names to info
+    pub fn as_hashmap(
+        &self,
+        device: &impl Device,
+    ) -> Result<HashMap<String, property::Info>, SystemError> {
+        let mut map = HashMap::new();
+        for id in self.prop_ids.iter() {
+            let info = device.get_property(*id)?;
+            let name = info.name().to_str().unwrap().to_owned();
+            map.insert(name, info);
+        }
+        Ok(map)
+    }
+
     /// Returns a pair representing a set of [`property::Handle`] and their raw values
     pub fn as_props_and_values(&self) -> (&[property::Handle], &[property::RawValue]) {
         (&self.prop_ids, &self.prop_vals)


### PR DESCRIPTION
I’m not super happy with the `as_hashmap()` name, feel free to bikeshed on that one. Especially because it does a lot of ioctls, that should get a name that looks more costly.

All together this reduces the number of `DRM_IOCTL_MODE_OBJ_GETPROPERTIES` from 32 to 12 in the atomic_modeset example, and the number of `DRM_IOCTL_MODE_GETPROPERTY` from 172 to 77.

A further improvement could be to only fetch the name (that is, do one call of getproperty instead of the whole call/allocation/call) and return a `HashMap<String, property::Handle>`, but non-example code probably want the whole property info to know what to actually set there.