### PR TITLE
Use `OwnedFd` and `BorrowedFd` where `RawFd` is used in API

### DIFF
--- a/examples/syncobj.rs
+++ b/examples/syncobj.rs
@@ -6,14 +6,13 @@ extern crate nix;
 pub mod utils;
 
 use nix::poll::PollFlags;
-use std::os::unix::io::AsFd;
+use std::os::unix::io::{AsFd, OwnedFd};
 use utils::*;
 
-use drm::control::syncobj::SyncFile;
 use drm::SystemError;
 
 impl Card {
-    fn simulate_command_submission(&self) -> Result<SyncFile, SystemError> {
+    fn simulate_command_submission(&self) -> Result<OwnedFd, SystemError> {
         // Create a temporary syncobj to receive the command fence.
         let syncobj = self.create_syncobj(false)?;
 

--- a/src/control/syncobj.rs
+++ b/src/control/syncobj.rs
@@ -13,7 +13,6 @@
 //! [`tokio::io::unix::AsyncFd`]: <https://docs.rs/tokio/latest/tokio/io/unix/struct.AsyncFd.html>
 
 use control;
-use std::os::unix::io::{AsFd, AsRawFd, FromRawFd, RawFd};
 
 /// A handle to a specific syncobj
 #[repr(transparent)]
@@ -46,33 +45,5 @@ impl From<control::RawResourceHandle> for Handle {
 impl std::fmt::Debug for Handle {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_tuple("syncobj::Handle").field(&self.0).finish()
-    }
-}
-
-#[derive(Debug)]
-/// A simple wrapper for a syncobj fd.
-pub struct SyncFile(std::fs::File);
-
-impl FromRawFd for SyncFile {
-    unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self(std::fs::File::from_raw_fd(fd))
-    }
-}
-
-/// Implementing [`AsFd`] is a prerequisite to implementing the traits found in this crate.
-/// Here, we are just calling [`std::fs::File::as_fd()`] on the inner File.
-impl AsFd for SyncFile {
-    fn as_fd(&self) -> std::os::unix::io::BorrowedFd<'_> {
-        self.0.as_fd()
-    }
-}
-
-/// Implementing [`AsRawFd`] allows SyncFile to be owned by [`tokio::io::unix::AsyncFd`];
-/// thereby integrating with its async/await runtime.
-///
-/// [`tokio::io::unix::AsyncFd`]: <https://docs.rs/tokio/latest/tokio/io/unix/struct.AsyncFd.html>
-impl AsRawFd for SyncFile {
-    fn as_raw_fd(&self) -> RawFd {
-        self.as_fd().as_raw_fd()
     }
 }


### PR DESCRIPTION
This is a breaking API change.