### PR TITLE
Use `i32` in `SystemError::Unknown` instead of `nix` `Errno`

### DIFF
--- a/drm-ffi/src/result.rs
+++ b/drm-ffi/src/result.rs
@@ -38,8 +38,8 @@ pub enum SystemError {
 
     /// Unknown system error.
     Unknown {
-        /// Unknown [`nix::errno::Errno`] returned by the system call.
-        errno: Errno,
+        /// Unknown errno value returned by the system call.
+        errno: i32,
     },
 }
 
@@ -53,7 +53,7 @@ impl fmt::Display for SystemError {
             SystemError::PermissionDenied => "permission denied",
             SystemError::UnknownFourcc => "unknown fourcc",
             SystemError::Unknown { errno } => {
-                return write!(fmt, "unknown system error: {}", errno)
+                return write!(fmt, "unknown system error: {}", Errno::from_i32(*errno))
             }
         })
     }
@@ -69,7 +69,9 @@ impl From<Errno> for SystemError {
             Errno::EINVAL => SystemError::InvalidArgument,
             Errno::ENOTTY => SystemError::InvalidFileDescriptor,
             Errno::EACCES => SystemError::PermissionDenied,
-            _ => SystemError::Unknown { errno },
+            _ => SystemError::Unknown {
+                errno: errno as i32,
+            },
         }
     }
 }


### PR DESCRIPTION
This way users of `drm` can match on constants from `libc`, or can convert it to the error types from any version of `nix` or `rustix`. This addresses a bit of awkwardness in https://github.com/Smithay/smithay/pull/1162 and https://github.com/rust-windowing/softbuffer/pull/164.

This should eliminate nix as a "public dependency" of `drm`, though it's still exposed by `drm-ffi`.