### PR TITLE
ffi: Make `ioctl` module private

### DIFF
--- a/drm-ffi/src/lib.rs
+++ b/drm-ffi/src/lib.rs
@@ -15,7 +15,7 @@ pub(crate) mod utils;
 
 use crate::result::SystemError as Error;
 pub mod gem;
-pub mod ioctl;
+mod ioctl;
 pub mod mode;
 pub mod result;
 pub mod syncobj;


### PR DESCRIPTION
The functions here all have wrappers, and the submodules of this module are all `pub(crate)`, so it seems unintentional that this is public.