### PR TITLE
Use Rustix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,19 +14,11 @@ bitflags = "2"
 bytemuck = { version = "1.12", features = ["extern_crate_alloc", "derive"] }
 drm-ffi = { path = "drm-ffi", version = "0.6.0" }
 drm-fourcc = "^2.2.0"
-
-[dependencies.nix]
-version = "0.27"
-default-features = false
-features = ["mman", "fs"]
-
-[dev-dependencies.nix]
-version = "0.27"
-default-features = false
-features = ["mman", "poll"]
+rustix = { version = "0.38.22", features = ["mm", "fs"] }
 
 [dev-dependencies]
 image = { version = "0.24", default-features = false, features = ["png"] }
+rustix = { version = "0.38.22", features = ["event", "mm"] }
 rustyline = "12"
 
 [features]

--- a/drm-ffi/Cargo.toml
+++ b/drm-ffi/Cargo.toml
@@ -10,11 +10,7 @@ edition = "2021"
 
 [dependencies]
 drm-sys = { path = "drm-sys", version = "0.5.0" }
-
-[dependencies.nix]
-version = "0.27"
-default-features = false
-features = ["ioctl"]
+rustix = { version = "0.38.22" }
 
 [features]
 use_bindgen = ["drm-sys/use_bindgen"]

--- a/drm-ffi/src/gem.rs
+++ b/drm-ffi/src/gem.rs
@@ -18,7 +18,7 @@ pub fn open(fd: BorrowedFd<'_>, name: u32) -> io::Result<drm_gem_open> {
     };
 
     unsafe {
-        ioctl::gem::open(fd.as_raw_fd(), &mut gem)?;
+        ioctl::gem::open(fd, &mut gem)?;
     }
 
     Ok(gem)
@@ -32,7 +32,7 @@ pub fn close(fd: BorrowedFd<'_>, handle: u32) -> io::Result<drm_gem_close> {
     };
 
     unsafe {
-        ioctl::gem::close(fd.as_raw_fd(), &gem)?;
+        ioctl::gem::close(fd, &gem)?;
     }
 
     Ok(gem)
@@ -47,7 +47,7 @@ pub fn handle_to_fd(fd: BorrowedFd<'_>, handle: u32, flags: u32) -> io::Result<d
     };
 
     unsafe {
-        ioctl::gem::prime_handle_to_fd(fd.as_raw_fd(), &mut prime)?;
+        ioctl::gem::prime_handle_to_fd(fd, &mut prime)?;
     }
 
     Ok(prime)
@@ -61,7 +61,7 @@ pub fn fd_to_handle(fd: BorrowedFd<'_>, primefd: BorrowedFd<'_>) -> io::Result<d
     };
 
     unsafe {
-        ioctl::gem::prime_fd_to_handle(fd.as_raw_fd(), &mut prime)?;
+        ioctl::gem::prime_fd_to_handle(fd, &mut prime)?;
     }
 
     Ok(prime)

--- a/drm-ffi/src/ioctl.rs
+++ b/drm-ffi/src/ioctl.rs
@@ -55,13 +55,6 @@ ioctl_readwrite!(get_bus_id, DRM_IOCTL_BASE, 0x01, drm_unique);
 /// # Nodes: Primary
 ioctl_readwrite!(get_client, DRM_IOCTL_BASE, 0x05, drm_client);
 
-/// Gets statistical information from the device
-///
-/// # Locks DRM mutex: No
-/// # Permissions: None
-/// # Nodes: Primary
-ioctl_read!(get_stats, DRM_IOCTL_BASE, 0x06, drm_stats);
-
 /// Get capabilities of the device.
 ///
 /// # Locks DRM mutex: No

--- a/drm-ffi/src/ioctl.rs
+++ b/drm-ffi/src/ioctl.rs
@@ -1,6 +1,45 @@
-#![allow(missing_docs)]
+use std::{ffi::c_uint, io, os::unix::io::BorrowedFd};
 
 use drm_sys::*;
+use rustix::ioctl::{
+    ioctl, Getter, NoArg, NoneOpcode, ReadOpcode, ReadWriteOpcode, Setter, Updater, WriteOpcode,
+};
+
+macro_rules! ioctl_readwrite {
+    ($name:ident, $ioty:expr, $nr:expr, $ty:ty) => {
+        pub unsafe fn $name(fd: BorrowedFd, data: &mut $ty) -> io::Result<()> {
+            type Opcode = ReadWriteOpcode<$ioty, $nr, $ty>;
+            Ok(ioctl(fd, Updater::<Opcode, $ty>::new(data))?)
+        }
+    };
+}
+
+macro_rules! ioctl_read {
+    ($name:ident, $ioty:expr, $nr:expr, $ty:ty) => {
+        pub unsafe fn $name(fd: BorrowedFd) -> io::Result<$ty> {
+            type Opcode = ReadOpcode<$ioty, $nr, $ty>;
+            Ok(ioctl(fd, Getter::<Opcode, $ty>::new())?)
+        }
+    };
+}
+
+macro_rules! ioctl_write_ptr {
+    ($name:ident, $ioty:expr, $nr:expr, $ty:ty) => {
+        pub unsafe fn $name(fd: BorrowedFd, data: &$ty) -> io::Result<()> {
+            type Opcode = WriteOpcode<$ioty, $nr, $ty>;
+            Ok(ioctl(fd, Setter::<Opcode, $ty>::new(*data))?)
+        }
+    };
+}
+
+macro_rules! ioctl_none {
+    ($name:ident, $ioty:expr, $nr:expr) => {
+        pub unsafe fn $name(fd: BorrowedFd) -> io::Result<()> {
+            type Opcode = NoneOpcode<$ioty, $nr, ()>;
+            Ok(ioctl(fd, NoArg::<Opcode>::new())?)
+        }
+    };
+}
 
 /// Gets the bus ID of the device
 ///
@@ -94,8 +133,7 @@ ioctl_readwrite!(get_irq_from_bus_id, DRM_IOCTL_BASE, 0x03, drm_irq_busid);
 ioctl_readwrite!(wait_vblank, DRM_IOCTL_BASE, 0x3a, drm_wait_vblank);
 
 pub(crate) mod mode {
-    use drm_sys::*;
-    use nix::libc::c_uint;
+    use super::*;
 
     /// Modesetting resources
     ioctl_readwrite!(get_resources, DRM_IOCTL_BASE, 0xA0, drm_mode_card_res);
@@ -198,7 +236,7 @@ pub(crate) mod mode {
 }
 
 pub(crate) mod gem {
-    use drm_sys::*;
+    use super::*;
 
     /// GEM related functions
     ioctl_readwrite!(open, DRM_IOCTL_BASE, 0x0b, drm_gem_open);
@@ -212,7 +250,7 @@ pub(crate) mod gem {
 }
 
 pub(crate) mod syncobj {
-    use drm_sys::*;
+    use super::*;
 
     /// Creates a syncobj.
     ioctl_readwrite!(create, DRM_IOCTL_BASE, 0xBF, drm_syncobj_create);

--- a/drm-ffi/src/lib.rs
+++ b/drm-ffi/src/lib.rs
@@ -147,6 +147,11 @@ pub fn set_capability(fd: BorrowedFd<'_>, cty: u64, val: bool) -> io::Result<drm
     Ok(cap)
 }
 
+/// Sets the requested interface version
+pub fn set_version(fd: BorrowedFd<'_>, version: &mut drm_set_version) -> io::Result<()> {
+    unsafe { ioctl::set_version(fd, version) }
+}
+
 /// Gets the driver version for this device.
 pub fn get_version(
     fd: BorrowedFd<'_>,

--- a/drm-ffi/src/mode.rs
+++ b/drm-ffi/src/mode.rs
@@ -7,10 +7,7 @@
 use crate::ioctl;
 use drm_sys::*;
 
-use std::{
-    io,
-    os::unix::io::{AsRawFd, BorrowedFd},
-};
+use std::{io, os::unix::io::BorrowedFd};
 
 /// Enumerate most card resources.
 pub fn get_resources(
@@ -22,7 +19,7 @@ pub fn get_resources(
 ) -> io::Result<drm_mode_card_res> {
     let mut sizes = drm_mode_card_res::default();
     unsafe {
-        ioctl::mode::get_resources(fd.as_raw_fd(), &mut sizes)?;
+        ioctl::mode::get_resources(fd, &mut sizes)?;
     }
 
     map_reserve!(fbs, sizes.count_fbs as usize);
@@ -43,7 +40,7 @@ pub fn get_resources(
     };
 
     unsafe {
-        ioctl::mode::get_resources(fd.as_raw_fd(), &mut res)?;
+        ioctl::mode::get_resources(fd, &mut res)?;
     }
 
     map_set!(fbs, res.count_fbs as usize);
@@ -61,7 +58,7 @@ pub fn get_plane_resources(
 ) -> io::Result<drm_mode_get_plane_res> {
     let mut sizes = drm_mode_get_plane_res::default();
     unsafe {
-        ioctl::mode::get_plane_resources(fd.as_raw_fd(), &mut sizes)?;
+        ioctl::mode::get_plane_resources(fd, &mut sizes)?;
     }
 
     if planes.is_none() {
@@ -76,7 +73,7 @@ pub fn get_plane_resources(
     };
 
     unsafe {
-        ioctl::mode::get_plane_resources(fd.as_raw_fd(), &mut res)?;
+        ioctl::mode::get_plane_resources(fd, &mut res)?;
     }
 
     map_set!(planes, res.count_planes as usize);
@@ -92,7 +89,7 @@ pub fn get_framebuffer(fd: BorrowedFd<'_>, fb_id: u32) -> io::Result<drm_mode_fb
     };
 
     unsafe {
-        ioctl::mode::get_fb(fd.as_raw_fd(), &mut info)?;
+        ioctl::mode::get_fb(fd, &mut info)?;
     }
 
     Ok(info)
@@ -119,7 +116,7 @@ pub fn add_fb(
     };
 
     unsafe {
-        ioctl::mode::add_fb(fd.as_raw_fd(), &mut fb)?;
+        ioctl::mode::add_fb(fd, &mut fb)?;
     }
 
     Ok(fb)
@@ -133,7 +130,7 @@ pub fn get_framebuffer2(fd: BorrowedFd<'_>, fb_id: u32) -> io::Result<drm_mode_f
     };
 
     unsafe {
-        ioctl::mode::get_fb2(fd.as_raw_fd(), &mut info)?;
+        ioctl::mode::get_fb2(fd, &mut info)?;
     }
 
     Ok(info)
@@ -164,7 +161,7 @@ pub fn add_fb2(
     };
 
     unsafe {
-        ioctl::mode::add_fb2(fd.as_raw_fd(), &mut fb)?;
+        ioctl::mode::add_fb2(fd, &mut fb)?;
     }
 
     Ok(fb)
@@ -173,7 +170,7 @@ pub fn add_fb2(
 /// Remove a framebuffer.
 pub fn rm_fb(fd: BorrowedFd<'_>, mut id: u32) -> io::Result<()> {
     unsafe {
-        ioctl::mode::rm_fb(fd.as_raw_fd(), &mut id)?;
+        ioctl::mode::rm_fb(fd, &mut id)?;
     }
 
     Ok(())
@@ -193,7 +190,7 @@ pub fn dirty_fb(
     };
 
     unsafe {
-        ioctl::mode::dirty_fb(fd.as_raw_fd(), &mut dirty)?;
+        ioctl::mode::dirty_fb(fd, &mut dirty)?;
     }
 
     Ok(dirty)
@@ -207,7 +204,7 @@ pub fn get_crtc(fd: BorrowedFd<'_>, crtc_id: u32) -> io::Result<drm_mode_crtc> {
     };
 
     unsafe {
-        ioctl::mode::get_crtc(fd.as_raw_fd(), &mut info)?;
+        ioctl::mode::get_crtc(fd, &mut info)?;
     }
 
     Ok(info)
@@ -239,7 +236,7 @@ pub fn set_crtc(
     };
 
     unsafe {
-        ioctl::mode::set_crtc(fd.as_raw_fd(), &mut crtc)?;
+        ioctl::mode::set_crtc(fd, &mut crtc)?;
     }
 
     Ok(crtc)
@@ -263,7 +260,7 @@ pub fn get_gamma(
     };
 
     unsafe {
-        ioctl::mode::get_gamma(fd.as_raw_fd(), &mut lut)?;
+        ioctl::mode::get_gamma(fd, &mut lut)?;
     }
 
     Ok(lut)
@@ -287,7 +284,7 @@ pub fn set_gamma(
     };
 
     unsafe {
-        ioctl::mode::set_gamma(fd.as_raw_fd(), &mut lut)?;
+        ioctl::mode::set_gamma(fd, &mut lut)?;
     }
 
     Ok(lut)
@@ -315,7 +312,7 @@ pub fn set_cursor(
     };
 
     unsafe {
-        ioctl::mode::cursor(fd.as_raw_fd(), &mut cursor)?;
+        ioctl::mode::cursor(fd, &mut cursor)?;
     }
 
     Ok(cursor)
@@ -350,7 +347,7 @@ pub fn set_cursor2(
     };
 
     unsafe {
-        ioctl::mode::cursor2(fd.as_raw_fd(), &mut cursor)?;
+        ioctl::mode::cursor2(fd, &mut cursor)?;
     }
 
     Ok(cursor)
@@ -373,7 +370,7 @@ pub fn move_cursor(
     };
 
     unsafe {
-        ioctl::mode::cursor(fd.as_raw_fd(), &mut cursor)?;
+        ioctl::mode::cursor(fd, &mut cursor)?;
     }
 
     Ok(cursor)
@@ -404,7 +401,7 @@ pub fn get_connector(
     };
 
     unsafe {
-        ioctl::mode::get_connector(fd.as_raw_fd(), &mut sizes)?;
+        ioctl::mode::get_connector(fd, &mut sizes)?;
     }
 
     let info = loop {
@@ -444,7 +441,7 @@ pub fn get_connector(
         };
 
         unsafe {
-            ioctl::mode::get_connector(fd.as_raw_fd(), &mut info)?;
+            ioctl::mode::get_connector(fd, &mut info)?;
         }
 
         if info.count_modes == sizes.count_modes
@@ -473,7 +470,7 @@ pub fn get_encoder(fd: BorrowedFd<'_>, encoder_id: u32) -> io::Result<drm_mode_g
     };
 
     unsafe {
-        ioctl::mode::get_encoder(fd.as_raw_fd(), &mut info)?;
+        ioctl::mode::get_encoder(fd, &mut info)?;
     }
 
     Ok(info)
@@ -491,7 +488,7 @@ pub fn get_plane(
     };
 
     unsafe {
-        ioctl::mode::get_plane(fd.as_raw_fd(), &mut sizes)?;
+        ioctl::mode::get_plane(fd, &mut sizes)?;
     }
 
     if formats.is_none() {
@@ -508,7 +505,7 @@ pub fn get_plane(
     };
 
     unsafe {
-        ioctl::mode::get_plane(fd.as_raw_fd(), &mut info)?;
+        ioctl::mode::get_plane(fd, &mut info)?;
     }
 
     map_set!(formats, info.count_format_types as usize);
@@ -548,7 +545,7 @@ pub fn set_plane(
     };
 
     unsafe {
-        ioctl::mode::set_plane(fd.as_raw_fd(), &mut plane)?;
+        ioctl::mode::set_plane(fd, &mut plane)?;
     }
 
     Ok(plane)
@@ -567,7 +564,7 @@ pub fn get_property(
     };
 
     unsafe {
-        ioctl::mode::get_property(fd.as_raw_fd(), &mut prop)?;
+        ioctl::mode::get_property(fd, &mut prop)?;
     }
 
     // There is no need to call get_property() twice if there is nothing else to retrieve.
@@ -582,7 +579,7 @@ pub fn get_property(
     prop.enum_blob_ptr = map_ptr!(&enums);
 
     unsafe {
-        ioctl::mode::get_property(fd.as_raw_fd(), &mut prop)?;
+        ioctl::mode::get_property(fd, &mut prop)?;
     }
 
     map_set!(values, prop.count_values as usize);
@@ -605,7 +602,7 @@ pub fn set_connector_property(
     };
 
     unsafe {
-        ioctl::mode::connector_set_property(fd.as_raw_fd(), &mut prop)?;
+        ioctl::mode::connector_set_property(fd, &mut prop)?;
     }
 
     Ok(prop)
@@ -623,7 +620,7 @@ pub fn get_property_blob(
     };
 
     unsafe {
-        ioctl::mode::get_blob(fd.as_raw_fd(), &mut sizes)?;
+        ioctl::mode::get_blob(fd, &mut sizes)?;
     }
 
     if data.is_none() {
@@ -639,7 +636,7 @@ pub fn get_property_blob(
     };
 
     unsafe {
-        ioctl::mode::get_blob(fd.as_raw_fd(), &mut blob)?;
+        ioctl::mode::get_blob(fd, &mut blob)?;
     }
 
     map_set!(data, blob.length as usize);
@@ -659,7 +656,7 @@ pub fn create_property_blob(
     };
 
     unsafe {
-        ioctl::mode::create_blob(fd.as_raw_fd(), &mut blob)?;
+        ioctl::mode::create_blob(fd, &mut blob)?;
     }
 
     Ok(blob)
@@ -670,7 +667,7 @@ pub fn destroy_property_blob(fd: BorrowedFd<'_>, id: u32) -> io::Result<drm_mode
     let mut blob = drm_mode_destroy_blob { blob_id: id };
 
     unsafe {
-        ioctl::mode::destroy_blob(fd.as_raw_fd(), &mut blob)?;
+        ioctl::mode::destroy_blob(fd, &mut blob)?;
     }
 
     Ok(blob)
@@ -693,7 +690,7 @@ pub fn get_properties(
     };
 
     unsafe {
-        ioctl::mode::obj_get_properties(fd.as_raw_fd(), &mut sizes)?;
+        ioctl::mode::obj_get_properties(fd, &mut sizes)?;
     }
 
     map_reserve!(props, sizes.count_props as usize);
@@ -708,7 +705,7 @@ pub fn get_properties(
     };
 
     unsafe {
-        ioctl::mode::obj_get_properties(fd.as_raw_fd(), &mut info)?;
+        ioctl::mode::obj_get_properties(fd, &mut info)?;
     }
 
     map_set!(props, info.count_props as usize);
@@ -733,7 +730,7 @@ pub fn set_property(
     };
 
     unsafe {
-        ioctl::mode::obj_set_property(fd.as_raw_fd(), &mut prop)?;
+        ioctl::mode::obj_set_property(fd, &mut prop)?;
     }
 
     Ok(())
@@ -757,7 +754,7 @@ pub fn page_flip(
     };
 
     unsafe {
-        ioctl::mode::crtc_page_flip(fd.as_raw_fd(), &mut flip)?;
+        ioctl::mode::crtc_page_flip(fd, &mut flip)?;
     }
 
     Ok(())
@@ -783,7 +780,7 @@ pub fn atomic_commit(
     };
 
     unsafe {
-        ioctl::mode::atomic(fd.as_raw_fd(), &mut atomic)?;
+        ioctl::mode::atomic(fd, &mut atomic)?;
     }
 
     Ok(())
@@ -803,7 +800,7 @@ pub fn create_lease(
     };
 
     unsafe {
-        ioctl::mode::create_lease(fd.as_raw_fd(), &mut data)?;
+        ioctl::mode::create_lease(fd, &mut data)?;
     }
 
     Ok(data)
@@ -817,7 +814,7 @@ pub fn list_lessees(
     let mut sizes = drm_mode_list_lessees::default();
 
     unsafe {
-        ioctl::mode::list_lessees(fd.as_raw_fd(), &mut sizes)?;
+        ioctl::mode::list_lessees(fd, &mut sizes)?;
     };
 
     map_reserve!(lessees, sizes.count_lessees as usize);
@@ -829,7 +826,7 @@ pub fn list_lessees(
     };
 
     unsafe {
-        ioctl::mode::list_lessees(fd.as_raw_fd(), &mut data)?;
+        ioctl::mode::list_lessees(fd, &mut data)?;
     };
 
     map_set!(lessees, data.count_lessees as usize);
@@ -845,7 +842,7 @@ pub fn get_lease(
     let mut sizes = drm_mode_get_lease::default();
 
     unsafe {
-        ioctl::mode::get_lease(fd.as_raw_fd(), &mut sizes)?;
+        ioctl::mode::get_lease(fd, &mut sizes)?;
     }
 
     map_reserve!(objects, sizes.count_objects as usize);
@@ -857,7 +854,7 @@ pub fn get_lease(
     };
 
     unsafe {
-        ioctl::mode::get_lease(fd.as_raw_fd(), &mut data)?;
+        ioctl::mode::get_lease(fd, &mut data)?;
     }
 
     map_set!(objects, data.count_objects as usize);
@@ -870,7 +867,7 @@ pub fn revoke_lease(fd: BorrowedFd<'_>, lessee_id: u32) -> io::Result<()> {
     let mut data = drm_mode_revoke_lease { lessee_id };
 
     unsafe {
-        ioctl::mode::revoke_lease(fd.as_raw_fd(), &mut data)?;
+        ioctl::mode::revoke_lease(fd, &mut data)?;
     }
 
     Ok(())
@@ -883,10 +880,7 @@ pub mod dumbbuffer {
     use crate::ioctl;
     use drm_sys::*;
 
-    use std::{
-        io,
-        os::unix::io::{AsRawFd, BorrowedFd},
-    };
+    use std::{io, os::unix::io::BorrowedFd};
 
     /// Create a dumb buffer
     pub fn create(
@@ -905,7 +899,7 @@ pub mod dumbbuffer {
         };
 
         unsafe {
-            ioctl::mode::create_dumb(fd.as_raw_fd(), &mut db)?;
+            ioctl::mode::create_dumb(fd, &mut db)?;
         }
 
         Ok(db)
@@ -916,7 +910,7 @@ pub mod dumbbuffer {
         let mut db = drm_mode_destroy_dumb { handle };
 
         unsafe {
-            ioctl::mode::destroy_dumb(fd.as_raw_fd(), &mut db)?;
+            ioctl::mode::destroy_dumb(fd, &mut db)?;
         }
 
         Ok(db)
@@ -936,7 +930,7 @@ pub mod dumbbuffer {
         };
 
         unsafe {
-            ioctl::mode::map_dumb(fd.as_raw_fd(), &mut map)?;
+            ioctl::mode::map_dumb(fd, &mut map)?;
         }
 
         Ok(map)

--- a/drm-ffi/src/syncobj.rs
+++ b/drm-ffi/src/syncobj.rs
@@ -22,7 +22,7 @@ pub fn create(fd: BorrowedFd<'_>, signaled: bool) -> io::Result<drm_syncobj_crea
     };
 
     unsafe {
-        ioctl::syncobj::create(fd.as_raw_fd(), &mut args)?;
+        ioctl::syncobj::create(fd, &mut args)?;
     }
 
     Ok(args)
@@ -33,7 +33,7 @@ pub fn destroy(fd: BorrowedFd<'_>, handle: u32) -> io::Result<drm_syncobj_destro
     let mut args = drm_syncobj_destroy { handle, pad: 0 };
 
     unsafe {
-        ioctl::syncobj::destroy(fd.as_raw_fd(), &mut args)?;
+        ioctl::syncobj::destroy(fd, &mut args)?;
     }
 
     Ok(args)
@@ -57,7 +57,7 @@ pub fn handle_to_fd(
     };
 
     unsafe {
-        ioctl::syncobj::handle_to_fd(fd.as_raw_fd(), &mut args)?;
+        ioctl::syncobj::handle_to_fd(fd, &mut args)?;
     }
 
     Ok(args)
@@ -81,7 +81,7 @@ pub fn fd_to_handle(
     };
 
     unsafe {
-        ioctl::syncobj::fd_to_handle(fd.as_raw_fd(), &mut args)?;
+        ioctl::syncobj::fd_to_handle(fd, &mut args)?;
     }
 
     Ok(args)
@@ -113,7 +113,7 @@ pub fn wait(
     };
 
     unsafe {
-        ioctl::syncobj::wait(fd.as_raw_fd(), &mut args)?;
+        ioctl::syncobj::wait(fd, &mut args)?;
     }
 
     Ok(args)
@@ -128,7 +128,7 @@ pub fn reset(fd: BorrowedFd<'_>, handles: &[u32]) -> io::Result<drm_syncobj_arra
     };
 
     unsafe {
-        ioctl::syncobj::reset(fd.as_raw_fd(), &mut args)?;
+        ioctl::syncobj::reset(fd, &mut args)?;
     }
 
     Ok(args)
@@ -143,7 +143,7 @@ pub fn signal(fd: BorrowedFd<'_>, handles: &[u32]) -> io::Result<drm_syncobj_arr
     };
 
     unsafe {
-        ioctl::syncobj::signal(fd.as_raw_fd(), &mut args)?;
+        ioctl::syncobj::signal(fd, &mut args)?;
     }
 
     Ok(args)
@@ -184,7 +184,7 @@ pub fn timeline_wait(
     };
 
     unsafe {
-        ioctl::syncobj::timeline_wait(fd.as_raw_fd(), &mut args)?;
+        ioctl::syncobj::timeline_wait(fd, &mut args)?;
     }
 
     Ok(args)
@@ -211,7 +211,7 @@ pub fn query(
     };
 
     unsafe {
-        ioctl::syncobj::query(fd.as_raw_fd(), &mut args)?;
+        ioctl::syncobj::query(fd, &mut args)?;
     }
 
     Ok(args)
@@ -235,7 +235,7 @@ pub fn transfer(
     };
 
     unsafe {
-        ioctl::syncobj::transfer(fd.as_raw_fd(), &mut args)?;
+        ioctl::syncobj::transfer(fd, &mut args)?;
     }
 
     Ok(args)
@@ -257,7 +257,7 @@ pub fn timeline_signal(
     };
 
     unsafe {
-        ioctl::syncobj::timeline_signal(fd.as_raw_fd(), &mut args)?;
+        ioctl::syncobj::timeline_signal(fd, &mut args)?;
     }
 
     Ok(args)

--- a/examples/ffi.rs
+++ b/examples/ffi.rs
@@ -63,13 +63,6 @@ fn print_token(fd: BorrowedFd<'_>) {
     println!("{:#?}", token);
 }
 
-/*
-fn print_stats(fd: BorrowedFd<'_>) {
-    let stats = ffi::basic::get_stats(fd);
-    println!("{:#?}", stats);
-}
-*/
-
 fn main() {
     let card = Card::open_global();
     let fd = card.as_fd();

--- a/examples/syncobj.rs
+++ b/examples/syncobj.rs
@@ -2,7 +2,7 @@
 pub mod utils;
 
 use crate::utils::*;
-use nix::poll::PollFlags;
+use rustix::event::PollFlags;
 use std::{
     io,
     os::unix::io::{AsFd, OwnedFd},
@@ -48,6 +48,6 @@ fn main() {
     // let afd = AsyncFd::with_interest(sync_file, Interest::READABLE).unwrap();
     // let future = async move { afd.readable().await.unwrap().retain_ready() };
     // future.await;
-    let mut poll_fds = [nix::poll::PollFd::new(&fd, PollFlags::POLLIN)];
-    nix::poll::poll(&mut poll_fds, -1).unwrap();
+    let mut poll_fds = [rustix::event::PollFd::new(&fd, PollFlags::IN)];
+    rustix::event::poll(&mut poll_fds, -1).unwrap();
 }

--- a/src/control/dumbbuffer.rs
+++ b/src/control/dumbbuffer.rs
@@ -65,10 +65,9 @@ impl DerefMut for DumbMapping<'_> {
 
 impl<'a> Drop for DumbMapping<'a> {
     fn drop(&mut self) {
-        use nix::sys::mman;
-
         unsafe {
-            mman::munmap(self.map.as_mut_ptr() as *mut _, self.map.len()).expect("Unmap failed");
+            rustix::mm::munmap(self.map.as_mut_ptr() as *mut _, self.map.len())
+                .expect("Unmap failed");
         }
     }
 }

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -63,8 +63,6 @@ use std::time::Duration;
 
 use core::num::NonZeroU32;
 
-pub use rustix::fs::OFlags;
-
 /// Raw handle for a drm resource
 pub type RawResourceHandle = NonZeroU32;
 
@@ -958,13 +956,9 @@ pub trait Device: super::Device {
     fn create_lease(
         &self,
         objects: &[RawResourceHandle],
-        flags: OFlags,
+        flags: u32,
     ) -> io::Result<(LeaseId, OwnedFd)> {
-        let lease = ffi::mode::create_lease(
-            self.as_fd(),
-            bytemuck::cast_slice(objects),
-            flags.bits() as u32,
-        )?;
+        let lease = ffi::mode::create_lease(self.as_fd(), bytemuck::cast_slice(objects), flags)?;
         Ok((
             unsafe { NonZeroU32::new_unchecked(lease.lessee_id) },
             unsafe { OwnedFd::from_raw_fd(lease.fd as RawFd) },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ use std::{
     os::unix::{ffi::OsStringExt, io::AsFd},
 };
 
-use nix::libc::EINVAL;
+use rustix::io::Errno;
 
 use crate::util::*;
 
@@ -192,7 +192,7 @@ pub trait Device: AsFd {
 
         let high_crtc_mask = _DRM_VBLANK_HIGH_CRTC_MASK >> _DRM_VBLANK_HIGH_CRTC_SHIFT;
         if (high_crtc & !high_crtc_mask) != 0 {
-            return Err(io::Error::from_raw_os_error(EINVAL));
+            return Err(Errno::INVAL.into());
         }
 
         let (sequence, wait_type) = match target_sequence {


### PR DESCRIPTION
Updates `drm-ffi` to use Rustix.

Based on https://github.com/Smithay/drm-rs/pull/179.
    
Not *too* hard to update by defining macros like Nix had, though it's probably not ideal.

The generic ioctl API for Rustix seems a bit awkward when dealing with APIs like drm that involve very large numbers of ioctls. Instead of generating functions with a macro like this, it's possible to define types aliases with `ReadWriteOpcode`, etc. But it's still necessary to deal with `Getter`/`Setter`, etc...