### PR TITLE
Provide `drm::RDWR` and `drm::CLOEXEC`

### DIFF
--- a/drm-ffi/drm-sys/src/lib.rs
+++ b/drm-ffi/drm-sys/src/lib.rs
@@ -4,14 +4,22 @@
 #![allow(non_snake_case)]
 
 #[cfg(any(target_os = "android", target_os = "linux"))]
-pub use linux_raw_sys::general::__kernel_size_t;
-#[cfg(any(target_os = "android", target_os = "linux"))]
-pub type drm_handle_t = core::ffi::c_uint;
+mod platform {
+    pub use linux_raw_sys::general::__kernel_size_t;
+    pub type drm_handle_t = core::ffi::c_uint;
+    pub const DRM_RDWR: u32 = linux_raw_sys::general::O_RDWR;
+    pub const DRM_CLOEXEC: u32 = linux_raw_sys::general::O_CLOEXEC;
+}
 
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
-type __kernel_size_t = libc::size_t;
-#[cfg(not(any(target_os = "android", target_os = "linux")))]
-pub type drm_handle_t = core::ffi::c_ulong;
+mod platform {
+    pub type __kernel_size_t = libc::size_t;
+    pub type drm_handle_t = core::ffi::c_ulong;
+    pub const DRM_RDWR: u32 = libc::O_RDWR as u32;
+    pub const DRM_CLOEXEC: u32 = libc::O_CLOEXEC as u32;
+}
+
+pub use platform::*;
 
 #[cfg(feature = "use_bindgen")]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@ use rustix::io::Errno;
 
 use crate::util::*;
 
+pub use drm_ffi::{DRM_CLOEXEC as CLOEXEC, DRM_RDWR as RDWR};
+
 /// This trait should be implemented by any object that acts as a DRM device. It
 /// is a prerequisite for using any DRM functionality.
 ///


### PR DESCRIPTION
Although these should match `libc`, this is convenient and avoids adding `libc` or `rustix` as a dependency in consuming crates.

Fixes https://github.com/Smithay/drm-rs/issues/182.