### PR TITLE
ffi: fix build with libdrm 2.4.120

### DIFF
--- a/drm-ffi/src/syncobj.rs
+++ b/drm-ffi/src/syncobj.rs
@@ -110,6 +110,7 @@ pub fn wait(
         },
         first_signaled: 0,
         pad: 0,
+        deadline_nsec: 0,
     };
 
     unsafe {
@@ -181,6 +182,7 @@ pub fn timeline_wait(
         },
         first_signaled: 0,
         pad: 0,
+        deadline_nsec: 0,
     };
 
     unsafe {


### PR DESCRIPTION
libdrm 2.4.120 introduced a new field with https://gitlab.freedesktop.org/mesa/drm/-/commit/6c4392f49bdd0b34590ae646868229318f880f81 