### PR TITLE
Fix unaligned memory access when reading DRM events

### DIFF
--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -1144,8 +1144,6 @@ impl Iterator for Events {
             self.i += event.length as usize;
             match event.type_ {
                 ffi::DRM_EVENT_VBLANK => {
-                    #[allow(unknown_lints)]
-                    #[allow(invalid_reference_casting)]
                     let vblank_event = unsafe {
                         std::ptr::read_unaligned(event_ptr as *const ffi::drm_event_vblank)
                     };
@@ -1161,8 +1159,6 @@ impl Iterator for Events {
                     }))
                 }
                 ffi::DRM_EVENT_FLIP_COMPLETE => {
-                    #[allow(unknown_lints)]
-                    #[allow(invalid_reference_casting)]
                     let vblank_event = unsafe {
                         std::ptr::read_unaligned(event_ptr as *const ffi::drm_event_vblank)
                     };


### PR DESCRIPTION
Running with debug assertions enabled on armv7 (an stm32mp157) panics due to unaligned memory reads:

thread 'main' panicked at 'misaligned pointer dereference: address must be a multiple of 0x8 but is 0xbec90b44', .../drm-0.9.0/src/control/mod.rs:906:34

Fix this by using the corresponding functions from core to safely copy the data (in C we'd do a memcpy).