### PR TITLE
Fix drm::control::Device::add_planar_buffer when GBM Bo uses DrmModifier::Invalid

### DIFF
--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -353,7 +353,9 @@ pub trait Device: super::Device {
     where
         B: buffer::PlanarBuffer + ?Sized,
     {
-        let modifier = planar_buffer.modifier();
+        let modifier = planar_buffer
+            .modifier()
+            .filter(|modifier| !matches!(modifier, DrmModifier::Invalid));
         let has_modifier = flags.contains(FbCmd2Flags::MODIFIERS);
         assert!((has_modifier && modifier.is_some()) || (!has_modifier && modifier.is_none()));
         let modifier = if let Some(modifier) = modifier {


### PR DESCRIPTION
When adding a GBM supplied buffer via add_planar_buffer, since commit 6cb3a27d5b3f4fecb5415bed69497491759126a9 the modifiers are fetched directly from the planar buffer trait. What the code does not take into account though is when the GBM bo returns DrmModifier::Invalid. In that case add_fb2 expects 0 as modifier in the array for each plane, instead of DRM_FORMAT_MOD_INVALID.