### PR TITLE
Impl Display for connectors (and more)

### DIFF
--- a/src/control/connector.rs
+++ b/src/control/connector.rs
@@ -60,6 +60,12 @@ pub struct Info {
     pub(crate) subpixel: SubPixel,
 }
 
+impl std::fmt::Display for Info {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}-{}", self.interface.as_str(), self.interface_id)
+    }
+}
+
 impl Info {
     /// Returns the handle to this connector.
     pub fn handle(&self) -> Handle {

--- a/src/control/crtc.rs
+++ b/src/control/crtc.rs
@@ -62,6 +62,12 @@ pub struct Info {
     pub(crate) gamma_length: u32,
 }
 
+impl std::fmt::Display for Info {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CRTC {}", self.handle.0)
+    }
+}
+
 impl Info {
     /// Returns the handle to this CRTC.
     pub fn handle(&self) -> Handle {

--- a/src/control/encoder.rs
+++ b/src/control/encoder.rs
@@ -53,6 +53,12 @@ pub struct Info {
     pub(crate) pos_clones: u32,
 }
 
+impl std::fmt::Display for Info {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Encoder {}", self.handle.0)
+    }
+}
+
 impl Info {
     /// Returns the handle to this encoder.
     pub fn handle(&self) -> Handle {

--- a/src/control/framebuffer.rs
+++ b/src/control/framebuffer.rs
@@ -55,6 +55,12 @@ pub struct Info {
     pub(crate) buffer: Option<buffer::Handle>,
 }
 
+impl std::fmt::Display for Info {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Framebuffer {}", self.handle.0)
+    }
+}
+
 impl Info {
     /// Returns the handle to this framebuffer.
     pub fn handle(&self) -> Handle {

--- a/src/control/plane.rs
+++ b/src/control/plane.rs
@@ -65,6 +65,12 @@ pub struct Info {
     pub(crate) formats: Vec<u32>,
 }
 
+impl std::fmt::Display for Info {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Plane {}", self.handle.0)
+    }
+}
+
 impl Info {
     /// Returns the handle to this plane.
     pub fn handle(&self) -> Handle {


### PR DESCRIPTION
Having `Display` for connectors is handy. The format is a fairly well established nomenclature: `"<connector>-<id>"`. 

I've added impls for other commonly used objects as a separate patch. It's less obviously useful, but still useful IMHO.

This PR prevents excessive usage of `:?` or newtypes by users of this library.