### PR TITLE
control: Add `Device::crtc_get/queue_sequence()` IOCTLs and event

### DIFF
--- a/drm-ffi/src/ioctl.rs
+++ b/drm-ffi/src/ioctl.rs
@@ -125,6 +125,31 @@ ioctl_readwrite!(get_irq_from_bus_id, DRM_IOCTL_BASE, 0x03, drm_irq_busid);
 /// # Nodes: Primary
 ioctl_readwrite!(wait_vblank, DRM_IOCTL_BASE, 0x3a, drm_wait_vblank);
 
+// TODO: Move into mode?
+/// Query current scanout sequence number
+///
+/// # Locks DRM mutex: ?
+/// # Permissions: None
+/// # Nodes: Primary
+ioctl_readwrite!(
+    crtc_get_sequence,
+    DRM_IOCTL_BASE,
+    0x3b,
+    drm_crtc_get_sequence
+);
+
+/// Queue event to be delivered at specified sequence
+///
+/// # Locks DRM mutex: ?
+/// # Permissions: None
+/// # Nodes: Primary
+ioctl_readwrite!(
+    crtc_queue_sequence,
+    DRM_IOCTL_BASE,
+    0x3c,
+    drm_crtc_queue_sequence
+);
+
 pub(crate) mod mode {
     use super::*;
 

--- a/drm-ffi/src/lib.rs
+++ b/drm-ffi/src/lib.rs
@@ -207,9 +207,40 @@ pub fn wait_vblank(
         signal: signal as c_ulong,
     };
 
-    unsafe {
-        ioctl::wait_vblank(fd, &mut wait_vblank)?;
-    };
+    unsafe { ioctl::wait_vblank(fd, &mut wait_vblank) }?;
 
     Ok(unsafe { wait_vblank.reply })
+}
+
+/// Query current scanout sequence number.
+pub fn crtc_get_sequence(fd: BorrowedFd<'_>, crtc_id: u32) -> io::Result<drm_crtc_get_sequence> {
+    let mut get_seq = drm_crtc_get_sequence {
+        crtc_id,
+        ..Default::default()
+    };
+
+    unsafe { ioctl::crtc_get_sequence(fd, &mut get_seq) }?;
+
+    Ok(get_seq)
+}
+
+/// Queue event to be delivered at specified sequence. Time stamp marks when the first pixel of the
+/// refresh cycle leaves the display engine for the display
+pub fn crtc_queue_sequence(
+    fd: BorrowedFd<'_>,
+    crtc_id: u32,
+    flags: u32,
+    sequence: u64,
+    user_data: u64,
+) -> io::Result<drm_crtc_queue_sequence> {
+    let mut queue_seq = drm_crtc_queue_sequence {
+        crtc_id,
+        flags,
+        sequence,
+        user_data,
+    };
+
+    unsafe { ioctl::crtc_queue_sequence(fd, &mut queue_seq) }?;
+
+    Ok(queue_seq)
 }


### PR DESCRIPTION
These two IOCTLs are for querying the most recent sequence number (and its "first pixel out" timestamp) as well as scheduling (queueing) an event when a future sequence number (absolute or relative) is hit, equally containing the "first pixel out" timestamp for that sequence.

As with `wait_vblank()`, `crtc_queue_sequence()` also returns the absolute sequence number that the event ended up latching on.  This is useful when specifying a relative index as well as when the driver `max()`es an absolute target to the most recently triggered sequence. This request will still result in an event even when that sequence number has already been hit, but doesn't allow you to queue older frames.

### To figure out

- [ ] Do the new IOCTLs belong to the mode, or outside of it (i.e. in `src/lib.rs` or `src/control/mod.rs`)?
- [ ] Since events can be fired for `wait_vblank()` which is outside of `control`, should `receive_events()` be moved to the (or is the optional `wait_vblank(EVENT, ...)` flag a feature of a modesetting device)?
- [ ] Where to find if `Locks DRM mutex` should be true or false?

### "Unrelated" TODOs

Note that this PR is much bigger than just these two IOCTLs, as I started cleaning through and playing with the code. There are a bunch of `TODO`s remaining in the code, mostly questions for the maintainers to decide how to proceed. And a lot of unrelated changes to be split out.

- [ ] Expose `user_data` field on `page_flip()` just like `wait_vblank()`, since the `crtc_id` field will always be set from kernel `4.12` onwards?
- [ ] Remove getter functions from PODs and make their fields `pub`? I.e. `ResourceHandles` already has `pub` fields and doesn't need trivial getters, `WaitVblankReply` could use the same.
- [ ] Merge `PageFlipTarget` and `WaitVblankTarget`?
- [ ] Use more `doc(alias)` to make it easier to relate low-level DRM code to the higher-level wrappers here.
- [ ] Use more intradoc links to link i.e. events, their register functions, and flags together. Same for `Capabilities` when they affect a specific function/struct/field/flag.
- [ ] Make the `Events` iterator (basically a buffered reader) consume events from the `fd` indefinitely? Or at the very least document that it reads `1024` bytes of data (rounded down to a whole number of events that would fit), leaving them unaware of whether more events are available unless they keep calling `read_events()` in a loop till it returns an empty iterator?