### PR TITLE
Add `(major, minor, patchlevel)` to `Driver` `get_version()` probe

### DIFF
--- a/drm-ffi/src/lib.rs
+++ b/drm-ffi/src/lib.rs
@@ -160,9 +160,7 @@ pub fn get_version(
     mut desc_buf: Option<&mut Vec<i8>>,
 ) -> io::Result<drm_version> {
     let mut sizes = drm_version::default();
-    unsafe {
-        ioctl::get_version(fd, &mut sizes)?;
-    }
+    unsafe { ioctl::get_version(fd, &mut sizes) }?;
 
     map_reserve!(name_buf, sizes.name_len as usize);
     map_reserve!(date_buf, sizes.date_len as usize);
@@ -178,9 +176,7 @@ pub fn get_version(
         ..Default::default()
     };
 
-    unsafe {
-        ioctl::get_version(fd, &mut version)?;
-    }
+    unsafe { ioctl::get_version(fd, &mut version) }?;
 
     map_set!(name_buf, version.name_len as usize);
     map_set!(date_buf, version.date_len as usize);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,18 +165,24 @@ pub trait Device: AsFd {
         let mut date = Vec::new();
         let mut desc = Vec::new();
 
-        let _ = drm_ffi::get_version(
+        let v = drm_ffi::get_version(
             self.as_fd(),
             Some(&mut name),
             Some(&mut date),
             Some(&mut desc),
         )?;
 
+        let version = (v.version_major, v.version_minor, v.version_patchlevel);
         let name = OsString::from_vec(unsafe { transmute_vec(name) });
         let date = OsString::from_vec(unsafe { transmute_vec(date) });
         let desc = OsString::from_vec(unsafe { transmute_vec(desc) });
 
-        let driver = Driver { name, date, desc };
+        let driver = Driver {
+            version,
+            name,
+            date,
+            desc,
+        };
 
         Ok(driver)
     }
@@ -238,6 +244,8 @@ pub struct AuthToken(u32);
 /// Driver version of a device.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct Driver {
+    /// Version of the driver in `(major, minor, patchlevel)` format
+    pub version: (i32, i32, i32),
     /// Name of the driver
     pub name: OsString,
     /// Date driver was published


### PR DESCRIPTION
`struct drm_version` contains actual version fields, beyond the strings for the driver name, deveice description and date string.  Add a tuple field for this to `struct Driver`.
