### PR TITLE
freebsd: include missing libc crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ drm-ffi = { path = "drm-ffi", version = "0.9.0" }
 drm-fourcc = "^2.2.0"
 rustix = { version = "0.38.22", features = ["mm", "fs"] }
 
+[target.'cfg(target_os = "freebsd")'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 image = { version = "0.24", default-features = false, features = ["png"] }
 rustix = { version = "0.38.22", features = ["event", "mm"] }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -314,7 +314,7 @@ pub fn dev_path(dev: dev_t, ty: NodeType) -> io::Result<PathBuf> {
 
 /// Returns the path of a specific type of node from the DRM device described by major and minor device numbers.
 #[cfg(target_os = "freebsd")]
-fn dev_path(dev: dev_t, ty: NodeType) -> io::Result<PathBuf> {
+pub fn dev_path(dev: dev_t, ty: NodeType) -> io::Result<PathBuf> {
     // Based on libdrm `drmGetMinorNameForFD`. Should be updated if the code
     // there is replaced with anything more sensible...
 
@@ -352,7 +352,7 @@ fn dev_path(dev: dev_t, ty: NodeType) -> io::Result<PathBuf> {
 
 /// Returns the path of a specific type of node from the DRM device described by major and minor device numbers.
 #[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
-fn dev_path(dev: dev_t, ty: NodeType) -> io::Result<PathBuf> {
+pub fn dev_path(dev: dev_t, ty: NodeType) -> io::Result<PathBuf> {
     use std::io::ErrorKind;
 
     if !is_device_drm(dev) {


### PR DESCRIPTION
This causes compilation issues with the libc references in the devname_r definition in the devname function. With this compiling on freebsd succeeds.

Also make the non-linux versions of dev_path public, so other OS types can call it.