### PR TITLE
CI: Combine MSRV-check with `-Zminimal-versions` build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,10 +69,17 @@ jobs:
           sudo apt-get install -y libdrm-dev
       - name: Fetch drm headers
         run: ./.github/workflows/fetch_headers.sh
-      - name: Update deps
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          default: true
+          override: true
+      - name: Generate minimal-versions lockfile
         uses: actions-rs/cargo@v1
         with:
-          command: update
+          command: generate-lockfile
+          args: -Z minimal-versions
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.66.0
@@ -80,8 +87,6 @@ jobs:
           components: clippy
           default: true
           override: true
-      - name: Downgrade home
-        run: cargo update -p home --precise 0.5.5
       - name: Cargo cache
         uses: actions/cache@v3
         with:
@@ -99,43 +104,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all --all-features --all-targets -- -D warnings -A clippy::redundant_static_lifetimes
-
-  check-minimal:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      - run: |
-          sudo apt-get update -y
-          sudo apt-get install -y libdrm-dev
-      - name: Fetch drm headers
-        run: ./.github/workflows/fetch_headers.sh
-      - name: Update deps
-        uses: actions-rs/cargo@v1
-        with:
-          command: update
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          default: true
-          override: true
-      - name: Cargo cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-rust_nightly-${{ hashFiles('**/Cargo.toml') }}
-      - name: Build cache
-        uses: actions/cache@v3
-        with:
-          path: target
-          key: ${{ runner.os }}-build-rust_nightly-check-minimal-${{ hashFiles('**/Cargo.toml') }}
-      - name: Check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --all --all-features --all-targets -Z minimal-versions
 
   test:
     needs:
@@ -310,7 +278,6 @@ jobs:
       - format
       - doc
       - check
-      - check-minimal
       - test
     runs-on: ubuntu-22.04
     steps:

--- a/drm-ffi/drm-sys/Cargo.toml
+++ b/drm-ffi/drm-sys/Cargo.toml
@@ -15,7 +15,7 @@ use_bindgen = ["bindgen", "pkg-config"]
 update_bindings = ["use_bindgen"]
 
 [build-dependencies]
-bindgen = { version = "0.69.1", optional = true }
+bindgen = { version = "0.69.3", optional = true }
 pkg-config = { version = "0.3.19", optional = true }
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -16,13 +16,13 @@
 //! There are two methods of sharing a GEM handle between processes:
 //!
 //! 1. Using `Flink` to globally publish a handle using a 32-bit 'name'. This
-//! requires either holding the DRM Master lock or having the process'
-//! [`AuthToken`](struct@crate::AuthToken) authenticated. However, any process can
-//! open these handles if they know (or even guess) the global name.
+//!    requires either holding the DRM Master lock or having the process'
+//!    [`AuthToken`](struct@crate::AuthToken) authenticated. However, any process can
+//!    open these handles if they know (or even guess) the global name.
 //!
 //! 2. Converting the GEM handle into a PRIME file descriptor, and passing it
-//! like a regular one. This allows better control and security, and is the
-//! recommended method of sharing buffers.
+//!    like a regular one. This allows better control and security, and is the
+//!    recommended method of sharing buffers.
 
 use crate::control;
 pub use drm_fourcc::{DrmFourcc, DrmModifier, DrmVendor, UnrecognizedFourcc, UnrecognizedVendor};

--- a/src/control/dumbbuffer.rs
+++ b/src/control/dumbbuffer.rs
@@ -63,7 +63,7 @@ impl DerefMut for DumbMapping<'_> {
     }
 }
 
-impl<'a> Drop for DumbMapping<'a> {
+impl Drop for DumbMapping<'_> {
     fn drop(&mut self) {
         unsafe {
             rustix::mm::munmap(self.map.as_mut_ptr() as *mut _, self.map.len())

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -6,20 +6,20 @@
 //! exposing the following resource types:
 //!
 //! * FrameBuffer - Specific to an individual process, these wrap around generic
-//! GPU buffers so that they can be attached to a Plane.
+//!   GPU buffers so that they can be attached to a Plane.
 //!
 //! * Planes - Dedicated memory objects which contain a buffer that can then be
-//! scanned out by a CRTC. There exist a few different types of planes depending
-//! on the use case.
+//!   scanned out by a CRTC. There exist a few different types of planes depending
+//!   on the use case.
 //!
 //! * CRTC - Scanout engines that read pixel data from a Plane and sends it to
-//! a Connector. Each CRTC has at least one Primary Plane.
+//!   a Connector. Each CRTC has at least one Primary Plane.
 //!
 //! * Connector - Represents the physical output, such as a DisplayPort or
-//! VGA connector.
+//!   VGA connector.
 //!
 //! * Encoder - Encodes pixel data from a CRTC into something a Connector can
-//! understand.
+//!   understand.
 //!
 //! Further details on each resource can be found in their respective modules.
 //!
@@ -214,7 +214,7 @@ pub trait Device: super::Device {
             },
             modes: Mode::wrap_vec(modes),
             encoders: unsafe { transmute_vec_from_u32(encoders) },
-            curr_enc: unsafe { mem::transmute(ffi_info.encoder_id) },
+            curr_enc: from_u32(ffi_info.encoder_id),
             subpixel: connector::SubPixel::from_raw(ffi_info.subpixel),
         };
 

--- a/src/control/plane.rs
+++ b/src/control/plane.rs
@@ -7,13 +7,13 @@
 //! types of planes available for use:
 //!
 //! * Primary - A CRTC's built-in plane. When attaching a framebuffer to a CRTC,
-//! it is actually being attached to this kind of plane.
+//!   it is actually being attached to this kind of plane.
 //!
 //! * Overlay - Can be overlaid on top of a primary plane, utilizing extremely
-//! fast hardware compositing.
+//!   fast hardware compositing.
 //!
 //! * Cursor - Similar to an overlay plane, these are typically used to display
-//! cursor type objects.
+//!   cursor type objects.
 
 use crate::control;
 use drm_ffi as ffi;


### PR DESCRIPTION
Sometimes dependency crates bump their MSRV beyond our MSRV in a patch release, and fail our CI in subsequent versions.  Instead of downgrading independent crates in CI every time this issue arises, combine it with our already-existing `-Zminimal-versions` check.  Instead of running this check on `nightly`, we only use that toolchain to generate a `Cargo.lock` and subsequently `check` the code on our MSRV toolchain.
