### PR TITLE
Update OpenBSD support to new drm API introduced in 6.9

### DIFF
--- a/src/node/constants.rs
+++ b/src/node/constants.rs
@@ -21,25 +21,10 @@ pub const DRM_MAJOR: u32 = 87;
 pub const DRM_MAJOR: u32 = 226;
 
 /// Primary DRM node prefix.
-#[cfg(not(target_os = "openbsd"))]
 pub const PRIMARY_NAME: &str = "card";
 
-/// Primary DRM node prefix.
-#[cfg(target_os = "openbsd")]
-pub const PRIMARY_NAME: &str = "drm";
-
 /// Control DRM node prefix.
-#[cfg(not(target_os = "openbsd"))]
 pub const CONTROL_NAME: &str = "controlD";
 
-/// Control DRM node prefix.
-#[cfg(target_os = "openbsd")]
-pub const CONTROL_NAME: &str = "drmC";
-
 /// Render DRM node prefix.
-#[cfg(not(target_os = "openbsd"))]
 pub const RENDER_NAME: &str = "renderD";
-
-/// Render DRM node prefix.
-#[cfg(target_os = "openbsd")]
-pub const RENDER_NAME: &str = "drmR";

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -86,7 +86,7 @@ impl DrmNode {
 
     /// Returns whether the DRM device has render nodes.
     pub fn has_render(&self) -> bool {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "openbsd"))]
         {
             node_path(self, NodeType::Render).is_ok()
         }
@@ -98,7 +98,7 @@ impl DrmNode {
             false
         }
 
-        #[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
+        #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "openbsd")))]
         {
             false
         }


### PR DESCRIPTION
This makes OpenBSD work properly on my machine.

WIP because it depends on a libc change in https://github.com/rust-lang/libc/pull/4285#issuecomment-2682420476

My rust experience is rather limited so I'm looking forward to hear how this could be improved.

One potential problem I see is that `devname()` is not thread-safe as is because the name buffer is static. Does this need to be copied safely, guarded by a lock or marked unsafe?
