### PR TITLE
[API Break] Make `control::property::Info::value_type` return `&` instead of clone

### DIFF
--- a/examples/planes.rs
+++ b/examples/planes.rs
@@ -24,7 +24,7 @@ fn display_plane(
     for (handle, value) in &props {
         let info = card.get_property(*handle)?;
         let name = info.name().to_str().unwrap().to_owned();
-        prop_map.insert(name, (info.value_type(), *value));
+        prop_map.insert(name, (info.value_type().clone(), *value));
     }
     let Value::Enum(Some(type_)) = convert_value(&prop_map["type"]) else {
         panic!("failed to convert plane type enum");

--- a/src/control/property.rs
+++ b/src/control/property.rs
@@ -76,8 +76,8 @@ impl Info {
     }
 
     /// Returns the ValueType of this property.
-    pub fn value_type(&self) -> ValueType {
-        self.val_type.clone()
+    pub fn value_type(&self) -> &ValueType {
+        &self.val_type
     }
 
     /// Returns whether this property is mutable.


### PR DESCRIPTION
It seems odd for this to return an owned value, when `::name()` doesn't. And it is useful to get a reference to the `ValueType`, so `ValueType::convert_value` can be used and just use the lifetime of the `Info` instead of the cloned `ValueType.`

I assume there's no reason not to do this, since callers can still clone as needed.

As a small API break, I think this should be merged whenever the next semver bump to the crate happens to be.