### PR TITLE
Add support for vec, slice & array in create_property_blob

### DIFF
--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -534,9 +534,12 @@ pub trait Device: super::Device {
     }
 
     /// Create a property blob value from a given data blob
-    fn create_property_blob<T>(&self, data: &T) -> io::Result<property::Value<'static>> {
+    fn create_property_blob<T>(&self, data: &[T]) -> io::Result<property::Value<'static>> {
         let data = unsafe {
-            std::slice::from_raw_parts_mut(data as *const _ as *mut u8, mem::size_of::<T>())
+            std::slice::from_raw_parts_mut(
+                data.as_ptr() as *mut u8,
+                data.len() * mem::size_of::<T>(),
+            )
         };
         let blob = ffi::mode::create_property_blob(self.as_fd(), data)?;
 

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -534,13 +534,9 @@ pub trait Device: super::Device {
     }
 
     /// Create a property blob value from a given data blob
-    fn create_property_blob<T>(&self, data: &[T]) -> io::Result<property::Value<'static>> {
-        let data = unsafe {
-            std::slice::from_raw_parts_mut(
-                data.as_ptr() as *mut u8,
-                data.len() * mem::size_of::<T>(),
-            )
-        };
+    fn create_property_blob<T: ?Sized>(&self, data: &T) -> io::Result<property::Value<'static>> {
+        let size = mem::size_of_val(data);
+        let data = unsafe { std::slice::from_raw_parts_mut(data as *const _ as *mut u8, size) };
         let blob = ffi::mode::create_property_blob(self.as_fd(), data)?;
 
         Ok(property::Value::Blob(blob.blob_id.into()))


### PR DESCRIPTION
To support vectors and slices in addition to arrays in the **create_property_blob** function, you can use generics and trait bounds to handle different types of data.

- The function now accepts a slice (&[T]) instead of a reference to a single object (&T).
- This allows the function to work with arrays, vectors and slices seamlessly since all of them can be converted to slices.
- The as_ptr() method is used to get a raw pointer to the slice's data.
- The length of the slice is multiplied by the size of the type T to calculate the total size in bytes

This modification ensures that the function is flexible and can handle different types of contiguous data structures.