### PR TITLE
node: Fix behavior on DragonFlyBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ drm-ffi = { path = "drm-ffi", version = "0.9.0" }
 drm-fourcc = "^2.2.0"
 rustix = { version = "1.0.7", features = ["mm", "fs"] }
 
-[target.'cfg(target_os = "freebsd")'.dependencies]
+[target.'cfg(any(target_os = "freebsd", target_os = "dragonfly"))'.dependencies]
 libc = "0.2"
 
 [dev-dependencies]

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -220,9 +220,9 @@ impl From<io::Error> for CreateDrmNodeError {
     }
 }
 
-#[cfg(target_os = "freebsd")]
+#[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
 fn devname(dev: dev_t) -> Option<String> {
-    use std::os::raw::{c_char, c_int};
+    use std::os::raw::c_char;
 
     // Matching value of SPECNAMELEN in FreeBSD 13+
     let mut dev_name = vec![0u8; 255];
@@ -232,7 +232,7 @@ fn devname(dev: dev_t) -> Option<String> {
             dev,
             libc::S_IFCHR, // Must be S_IFCHR or S_IFBLK
             dev_name.as_mut_ptr() as *mut c_char,
-            dev_name.len() as c_int,
+            dev_name.len() as _,
         )
     };
 
@@ -257,7 +257,7 @@ pub fn is_device_drm(dev: dev_t) -> bool {
 }
 
 /// Returns if the given device by major:minor pair is a DRM device.
-#[cfg(target_os = "freebsd")]
+#[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
 pub fn is_device_drm(dev: dev_t) -> bool {
     devname(dev).map_or(false, |dev_name| {
         dev_name.starts_with("drm/")
@@ -268,7 +268,7 @@ pub fn is_device_drm(dev: dev_t) -> bool {
 }
 
 /// Returns if the given device by major:minor pair is a DRM device.
-#[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
+#[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly")))]
 pub fn is_device_drm(dev: dev_t) -> bool {
     major(dev) == DRM_MAJOR
 }
@@ -329,7 +329,7 @@ pub fn dev_path(dev: dev_t, ty: NodeType) -> io::Result<PathBuf> {
 }
 
 /// Returns the path of a specific type of node from the DRM device described by major and minor device numbers.
-#[cfg(target_os = "freebsd")]
+#[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
 pub fn dev_path(dev: dev_t, ty: NodeType) -> io::Result<PathBuf> {
     // Based on libdrm `drmGetMinorNameForFD`. Should be updated if the code
     // there is replaced with anything more sensible...
@@ -366,7 +366,7 @@ pub fn dev_path(dev: dev_t, ty: NodeType) -> io::Result<PathBuf> {
 }
 
 /// Returns the path of a specific type of node from the DRM device described by major and minor device numbers.
-#[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
+#[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "dragonfly")))]
 pub fn dev_path(dev: dev_t, ty: NodeType) -> io::Result<PathBuf> {
     use std::io::ErrorKind;
 


### PR DESCRIPTION
DragonFlyBSD is similar to FreeBSD, so it should use the FreeBSD implementation here instead of the default implementation (which I guess is really just the NetBSD/OpenBSD implementation).

This now works properly, at least with this simple test:

```rust
use std::fs;

fn main() {
    for i in fs::read_dir("/dev/dri").unwrap() {
        let i = i.unwrap();
        let node = drm::node::DrmNode::from_path(i.path()).unwrap();
        println!("{}: {:?}", i.path().display(), node);
    }
}
```