### PR TITLE
update to rustix 1.0 and bump linux-raw-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,14 @@ bytemuck = { version = "1.14", features = ["extern_crate_alloc", "derive"] }
 bytemuck_derive = { version = "1.5" }
 drm-ffi = { path = "drm-ffi", version = "0.9.0" }
 drm-fourcc = "^2.2.0"
-rustix = { version = "0.38.22", features = ["mm", "fs"] }
+rustix = { version = "1.0.7", features = ["mm", "fs"] }
 
 [target.'cfg(target_os = "freebsd")'.dependencies]
 libc = "0.2"
 
 [dev-dependencies]
 image = { version = "0.24", default-features = false, features = ["png"] }
-rustix = { version = "0.38.22", features = ["event", "mm"] }
+rustix = { version = "1.0.7", features = ["event", "mm"] }
 rustyline = "13"
 
 [features]

--- a/drm-ffi/Cargo.toml
+++ b/drm-ffi/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 drm-sys = { path = "drm-sys", version = "0.8.0" }
-rustix = { version = "0.38.22" }
+rustix = { version = "1.0.7" }
 
 [features]
 use_bindgen = ["drm-sys/use_bindgen"]

--- a/drm-ffi/drm-sys/Cargo.toml
+++ b/drm-ffi/drm-sys/Cargo.toml
@@ -19,7 +19,7 @@ bindgen = { version = "0.70", optional = true }
 pkg-config = { version = "0.3.19", optional = true }
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
-linux-raw-sys = { version = "0.6", default-features = false, features = ["general", "no_std"] }
+linux-raw-sys = { version = "0.9", default-features = false, features = ["general", "no_std"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "linux")))'.dependencies]
 libc = "0.2"

--- a/drm-ffi/src/ioctl.rs
+++ b/drm-ffi/src/ioctl.rs
@@ -1,15 +1,13 @@
 use std::{ffi::c_uint, io, os::unix::io::BorrowedFd};
 
 use drm_sys::*;
-use rustix::ioctl::{
-    ioctl, Getter, NoArg, NoneOpcode, ReadOpcode, ReadWriteOpcode, Setter, Updater, WriteOpcode,
-};
+use rustix::ioctl::{ioctl, opcode, Getter, NoArg, Opcode, Setter, Updater};
 
 macro_rules! ioctl_readwrite {
     ($name:ident, $ioty:expr, $nr:expr, $ty:ty) => {
         pub unsafe fn $name(fd: BorrowedFd, data: &mut $ty) -> io::Result<()> {
-            type Opcode = ReadWriteOpcode<$ioty, $nr, $ty>;
-            Ok(ioctl(fd, Updater::<Opcode, $ty>::new(data))?)
+            const OPCODE: Opcode = opcode::read_write::<$ty>($ioty, $nr);
+            Ok(ioctl(fd, Updater::<OPCODE, $ty>::new(data))?)
         }
     };
 }
@@ -17,8 +15,8 @@ macro_rules! ioctl_readwrite {
 macro_rules! ioctl_read {
     ($name:ident, $ioty:expr, $nr:expr, $ty:ty) => {
         pub unsafe fn $name(fd: BorrowedFd) -> io::Result<$ty> {
-            type Opcode = ReadOpcode<$ioty, $nr, $ty>;
-            Ok(ioctl(fd, Getter::<Opcode, $ty>::new())?)
+            const OPCODE: Opcode = opcode::read::<$ty>($ioty, $nr);
+            Ok(ioctl(fd, Getter::<OPCODE, $ty>::new())?)
         }
     };
 }
@@ -26,8 +24,8 @@ macro_rules! ioctl_read {
 macro_rules! ioctl_write_ptr {
     ($name:ident, $ioty:expr, $nr:expr, $ty:ty) => {
         pub unsafe fn $name(fd: BorrowedFd, data: &$ty) -> io::Result<()> {
-            type Opcode = WriteOpcode<$ioty, $nr, $ty>;
-            Ok(ioctl(fd, Setter::<Opcode, $ty>::new(*data))?)
+            const OPCODE: Opcode = opcode::write::<$ty>($ioty, $nr);
+            Ok(ioctl(fd, Setter::<OPCODE, $ty>::new(*data))?)
         }
     };
 }
@@ -35,8 +33,8 @@ macro_rules! ioctl_write_ptr {
 macro_rules! ioctl_none {
     ($name:ident, $ioty:expr, $nr:expr) => {
         pub unsafe fn $name(fd: BorrowedFd) -> io::Result<()> {
-            type Opcode = NoneOpcode<$ioty, $nr, ()>;
-            Ok(ioctl(fd, NoArg::<Opcode>::new())?)
+            const OPCODE: Opcode = opcode::none($ioty, $nr);
+            Ok(ioctl(fd, NoArg::<OPCODE>::new())?)
         }
     };
 }

--- a/examples/syncobj.rs
+++ b/examples/syncobj.rs
@@ -49,5 +49,5 @@ fn main() {
     // let future = async move { afd.readable().await.unwrap().retain_ready() };
     // future.await;
     let mut poll_fds = [rustix::event::PollFd::new(&fd, PollFlags::IN)];
-    rustix::event::poll(&mut poll_fds, -1).unwrap();
+    rustix::event::poll(&mut poll_fds, None).unwrap();
 }


### PR DESCRIPTION
the only really relevant changes were the changes to the ioctl module, replacing the type generic with a const generic and the types with consts. see the last section of [rustix's `CHANGES.md`](https://github.com/bytecodealliance/rustix/blob/92466d9860d95aa15b8ad0a5ea4cb88b39ccc63f/CHANGES.md). the only other change was in an example where `-1` (meaning no timeout) was replaced with `None` (also meaning no timeout).

i also updated the `linux-raw-sys` dependency of `drm-sys` to match the version required by `rustix` 1, to avoid duplicating that dependency.