### PR TITLE
syncobj: Fix import_sync_file and add timeline exports/imports

### DIFF
--- a/drm-ffi/src/syncobj.rs
+++ b/drm-ffi/src/syncobj.rs
@@ -7,10 +7,7 @@ use drm_sys::*;
 
 use std::{
     io,
-    os::{
-        fd::{FromRawFd, OwnedFd},
-        unix::io::{AsRawFd, BorrowedFd},
-    },
+    os::fd::{AsRawFd, BorrowedFd},
 };
 
 /// Creates a syncobj.
@@ -43,7 +40,7 @@ pub fn destroy(fd: BorrowedFd<'_>, handle: u32) -> io::Result<drm_syncobj_destro
 }
 
 /// Exports a syncobj as an inter-process file descriptor.
-pub fn handle_to_fd(fd: BorrowedFd<'_>, handle: u32) -> io::Result<OwnedFd> {
+pub fn handle_to_fd(fd: BorrowedFd<'_>, handle: u32) -> io::Result<drm_syncobj_handle> {
     let mut args = drm_syncobj_handle {
         handle,
         flags: 0,
@@ -56,31 +53,40 @@ pub fn handle_to_fd(fd: BorrowedFd<'_>, handle: u32) -> io::Result<OwnedFd> {
         ioctl::syncobj::handle_to_fd(fd, &mut args)?;
     }
 
-    Ok(unsafe { OwnedFd::from_raw_fd(args.fd) })
+    Ok(args)
 }
 
-/// Exports a syncobj as a poll-able sync file.
+/// Exports a syncobj as a poll-able `sync_file` optionally for a specified timeline point.
 pub fn handle_to_sync_file(
     fd: BorrowedFd<'_>,
     handle: u32,
-) -> io::Result<OwnedFd> {
+    timeline_point: Option<u64>,
+) -> io::Result<drm_syncobj_handle> {
     let mut args = drm_syncobj_handle {
         handle,
-        flags: DRM_SYNCOBJ_HANDLE_TO_FD_FLAGS_EXPORT_SYNC_FILE,
+        flags: DRM_SYNCOBJ_HANDLE_TO_FD_FLAGS_EXPORT_SYNC_FILE
+            | if timeline_point.is_some() {
+                DRM_SYNCOBJ_HANDLE_TO_FD_FLAGS_TIMELINE
+            } else {
+                0
+            },
         fd: 0,
         pad: 0,
-        point: 0, // TODO: Add support for TIMELINE sync files
+        point: timeline_point.unwrap_or(0),
     };
 
     unsafe {
         ioctl::syncobj::handle_to_fd(fd, &mut args)?;
     }
 
-    Ok(unsafe { OwnedFd::from_raw_fd(args.fd) })
+    Ok(args)
 }
 
-/// Imports a file descriptor exported by [`handle_to_fd`] back into a process-local handle.
-pub fn fd_to_handle(fd: BorrowedFd<'_>, opaque_fd: BorrowedFd<'_>) -> io::Result<u32> {
+/// Imports a file descriptor exported by [`handle_to_fd()`] back into a process-local handle.
+pub fn fd_to_handle(
+    fd: BorrowedFd<'_>,
+    opaque_fd: BorrowedFd<'_>,
+) -> io::Result<drm_syncobj_handle> {
     let mut args = drm_syncobj_handle {
         handle: 0,
         flags: 0,
@@ -93,28 +99,35 @@ pub fn fd_to_handle(fd: BorrowedFd<'_>, opaque_fd: BorrowedFd<'_>) -> io::Result
         ioctl::syncobj::fd_to_handle(fd, &mut args)?;
     }
 
-    Ok(args.handle)
+    Ok(args)
 }
 
-/// Imports a sync file exported by [`handle_to_sync_file`] into an existing process-local handle.
+/// Imports a `sync_file` exported by [`handle_to_sync_file()`] into an existing process-local handle,
+/// optionally for a specified timeline point.
 pub fn sync_file_into_handle(
     fd: BorrowedFd<'_>,
     syncobj_fd: BorrowedFd<'_>,
     handle: u32,
-) -> io::Result<()> {
+    timeline_point: Option<u64>,
+) -> io::Result<drm_syncobj_handle> {
     let mut args = drm_syncobj_handle {
         handle,
-        flags: DRM_SYNCOBJ_FD_TO_HANDLE_FLAGS_IMPORT_SYNC_FILE,
+        flags: DRM_SYNCOBJ_FD_TO_HANDLE_FLAGS_IMPORT_SYNC_FILE
+            | if timeline_point.is_some() {
+                DRM_SYNCOBJ_FD_TO_HANDLE_FLAGS_TIMELINE
+            } else {
+                0
+            },
         fd: syncobj_fd.as_raw_fd(),
         pad: 0,
-        point: 0, // TODO: Add support for TIMELINE sync files
+        point: timeline_point.unwrap_or(0),
     };
 
     unsafe {
         ioctl::syncobj::fd_to_handle(fd, &mut args)?;
     }
 
-    Ok(())
+    Ok(args)
 }
 
 /// Waits for one or more syncobjs to become signalled.

--- a/drm-ffi/src/syncobj.rs
+++ b/drm-ffi/src/syncobj.rs
@@ -7,7 +7,10 @@ use drm_sys::*;
 
 use std::{
     io,
-    os::unix::io::{AsRawFd, BorrowedFd},
+    os::{
+        fd::{FromRawFd, OwnedFd},
+        unix::io::{AsRawFd, BorrowedFd},
+    },
 };
 
 /// Creates a syncobj.
@@ -39,19 +42,31 @@ pub fn destroy(fd: BorrowedFd<'_>, handle: u32) -> io::Result<drm_syncobj_destro
     Ok(args)
 }
 
-/// Exports a syncobj as an inter-process file descriptor or as a poll()-able sync file.
-pub fn handle_to_fd(
-    fd: BorrowedFd<'_>,
-    handle: u32,
-    export_sync_file: bool,
-) -> io::Result<drm_syncobj_handle> {
+/// Exports a syncobj as an inter-process file descriptor.
+pub fn handle_to_fd(fd: BorrowedFd<'_>, handle: u32) -> io::Result<OwnedFd> {
     let mut args = drm_syncobj_handle {
         handle,
-        flags: if export_sync_file {
-            DRM_SYNCOBJ_HANDLE_TO_FD_FLAGS_EXPORT_SYNC_FILE
-        } else {
-            0
-        },
+        flags: 0,
+        fd: 0,
+        pad: 0,
+        point: 0,
+    };
+
+    unsafe {
+        ioctl::syncobj::handle_to_fd(fd, &mut args)?;
+    }
+
+    Ok(unsafe { OwnedFd::from_raw_fd(args.fd) })
+}
+
+/// Exports a syncobj as a poll-able sync file.
+pub fn handle_to_sync_file(
+    fd: BorrowedFd<'_>,
+    handle: u32,
+) -> io::Result<OwnedFd> {
+    let mut args = drm_syncobj_handle {
+        handle,
+        flags: DRM_SYNCOBJ_HANDLE_TO_FD_FLAGS_EXPORT_SYNC_FILE,
         fd: 0,
         pad: 0,
         point: 0, // TODO: Add support for TIMELINE sync files
@@ -61,22 +76,35 @@ pub fn handle_to_fd(
         ioctl::syncobj::handle_to_fd(fd, &mut args)?;
     }
 
-    Ok(args)
+    Ok(unsafe { OwnedFd::from_raw_fd(args.fd) })
 }
 
 /// Imports a file descriptor exported by [`handle_to_fd`] back into a process-local handle.
-pub fn fd_to_handle(
-    fd: BorrowedFd<'_>,
-    syncobj_fd: BorrowedFd<'_>,
-    import_sync_file: bool,
-) -> io::Result<drm_syncobj_handle> {
+pub fn fd_to_handle(fd: BorrowedFd<'_>, opaque_fd: BorrowedFd<'_>) -> io::Result<u32> {
     let mut args = drm_syncobj_handle {
         handle: 0,
-        flags: if import_sync_file {
-            DRM_SYNCOBJ_FD_TO_HANDLE_FLAGS_IMPORT_SYNC_FILE
-        } else {
-            0
-        },
+        flags: 0,
+        fd: opaque_fd.as_raw_fd(),
+        pad: 0,
+        point: 0,
+    };
+
+    unsafe {
+        ioctl::syncobj::fd_to_handle(fd, &mut args)?;
+    }
+
+    Ok(args.handle)
+}
+
+/// Imports a sync file exported by [`handle_to_sync_file`] into an existing process-local handle.
+pub fn sync_file_into_handle(
+    fd: BorrowedFd<'_>,
+    syncobj_fd: BorrowedFd<'_>,
+    handle: u32,
+) -> io::Result<()> {
+    let mut args = drm_syncobj_handle {
+        handle,
+        flags: DRM_SYNCOBJ_FD_TO_HANDLE_FLAGS_IMPORT_SYNC_FILE,
         fd: syncobj_fd.as_raw_fd(),
         pad: 0,
         point: 0, // TODO: Add support for TIMELINE sync files
@@ -86,7 +114,7 @@ pub fn fd_to_handle(
         ioctl::syncobj::fd_to_handle(fd, &mut args)?;
     }
 
-    Ok(args)
+    Ok(())
 }
 
 /// Waits for one or more syncobjs to become signalled.

--- a/examples/syncobj.rs
+++ b/examples/syncobj.rs
@@ -24,7 +24,7 @@ impl Card {
             self.syncobj_signal(&[syncobj])?;
 
             // Export fence set by previous ioctl to file descriptor.
-            self.syncobj_to_sync_file(syncobj)
+            self.syncobj_to_sync_file(syncobj, None)
         };
 
         // The sync file descriptor constitutes ownership of the fence, so the syncobj can be

--- a/examples/syncobj.rs
+++ b/examples/syncobj.rs
@@ -24,7 +24,7 @@ impl Card {
             self.syncobj_signal(&[syncobj])?;
 
             // Export fence set by previous ioctl to file descriptor.
-            self.syncobj_to_fd(syncobj, true)
+            self.syncobj_to_sync_file(syncobj)
         };
 
         // The sync file descriptor constitutes ownership of the fence, so the syncobj can be

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -838,24 +838,32 @@ pub trait Device: super::Device {
         Ok(())
     }
 
-    /// Exports a syncobj as an inter-process file descriptor or as a poll()-able sync file.
-    fn syncobj_to_fd(
+    /// Exports a syncobj as an inter-process file descriptor.
+    fn syncobj_to_fd(&self, handle: syncobj::Handle) -> io::Result<OwnedFd> {
+        ffi::syncobj::handle_to_fd(self.as_fd(), handle.into())
+    }
+
+    /// Exports a syncobj as a poll-able sync file.
+    fn syncobj_to_sync_file(
         &self,
         handle: syncobj::Handle,
-        export_sync_file: bool,
     ) -> io::Result<OwnedFd> {
-        let info = ffi::syncobj::handle_to_fd(self.as_fd(), handle.into(), export_sync_file)?;
-        Ok(unsafe { OwnedFd::from_raw_fd(info.fd) })
+        ffi::syncobj::handle_to_sync_file(self.as_fd(), handle.into())
     }
 
     /// Imports a file descriptor exported by [`Self::syncobj_to_fd`] back into a process-local handle.
-    fn fd_to_syncobj(
+    fn fd_to_syncobj(&self, fd: BorrowedFd<'_>) -> io::Result<syncobj::Handle> {
+        let handle = ffi::syncobj::fd_to_handle(self.as_fd(), fd)?;
+        Ok(from_u32(handle).unwrap())
+    }
+
+    /// Imports a sync file exported by [`Self::syncobj_to_sync_file`] into an existing process-local handle.
+    fn sync_file_into_syncobj(
         &self,
         fd: BorrowedFd<'_>,
-        import_sync_file: bool,
-    ) -> io::Result<syncobj::Handle> {
-        let info = ffi::syncobj::fd_to_handle(self.as_fd(), fd, import_sync_file)?;
-        Ok(from_u32(info.handle).unwrap())
+        handle: syncobj::Handle,
+    ) -> io::Result<()> {
+        ffi::syncobj::sync_file_into_handle(self.as_fd(), fd, handle.into())
     }
 
     /// Waits for one or more syncobjs to become signalled.

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -840,30 +840,37 @@ pub trait Device: super::Device {
 
     /// Exports a syncobj as an inter-process file descriptor.
     fn syncobj_to_fd(&self, handle: syncobj::Handle) -> io::Result<OwnedFd> {
-        ffi::syncobj::handle_to_fd(self.as_fd(), handle.into())
+        let args = ffi::syncobj::handle_to_fd(self.as_fd(), handle.into())?;
+        Ok(unsafe { OwnedFd::from_raw_fd(args.fd) })
     }
 
-    /// Exports a syncobj as a poll-able sync file.
+    /// Exports a syncobj as a poll-able sync file optionally for a specified timeline point.
     fn syncobj_to_sync_file(
         &self,
         handle: syncobj::Handle,
+        timeline_point: Option<u64>,
     ) -> io::Result<OwnedFd> {
-        ffi::syncobj::handle_to_sync_file(self.as_fd(), handle.into())
+        let args = ffi::syncobj::handle_to_sync_file(self.as_fd(), handle.into(), timeline_point)?;
+        Ok(unsafe { OwnedFd::from_raw_fd(args.fd) })
     }
 
     /// Imports a file descriptor exported by [`Self::syncobj_to_fd`] back into a process-local handle.
     fn fd_to_syncobj(&self, fd: BorrowedFd<'_>) -> io::Result<syncobj::Handle> {
-        let handle = ffi::syncobj::fd_to_handle(self.as_fd(), fd)?;
-        Ok(from_u32(handle).unwrap())
+        let args = ffi::syncobj::fd_to_handle(self.as_fd(), fd)?;
+        Ok(from_u32(args.handle).unwrap())
     }
 
-    /// Imports a sync file exported by [`Self::syncobj_to_sync_file`] into an existing process-local handle.
+    /// Imports a sync file exported by [`Self::syncobj_to_sync_file`] into an existing process-local handle
+    /// optionally for a specified timeline point.
     fn sync_file_into_syncobj(
         &self,
         fd: BorrowedFd<'_>,
         handle: syncobj::Handle,
+        timeline_point: Option<u64>,
     ) -> io::Result<()> {
-        ffi::syncobj::sync_file_into_handle(self.as_fd(), fd, handle.into())
+        let _ =
+            ffi::syncobj::sync_file_into_handle(self.as_fd(), fd, handle.into(), timeline_point)?;
+        Ok(())
     }
 
     /// Waits for one or more syncobjs to become signalled.


### PR DESCRIPTION
This addresses the broken api reported in #224 and also provides entry point for the new optional timeline argument.

Ping @ids1024, @YaLTeR, @MarijnS95 