### PR TITLE
fix new rustc warnings from beta

### DIFF
--- a/src/control/property.rs
+++ b/src/control/property.rs
@@ -128,7 +128,7 @@ pub enum ValueType {
 
 impl ValueType {
     /// Given a [`RawValue`], convert it into a specific [`Value`]
-    pub fn convert_value(&self, value: RawValue) -> Value {
+    pub fn convert_value(&self, value: RawValue) -> Value<'_> {
         match self {
             ValueType::Unknown => Value::Unknown(value),
             ValueType::Boolean => Value::Boolean(value != 0),


### PR DESCRIPTION
running `cargo +beta check` on this crate currently generates this warning:

```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> src/control/property.rs:131:26
    |
131 |     pub fn convert_value(&self, value: RawValue) -> Value {
    |                          ^^^^^                      ----- the same lifetime is hidden here
    |                          |
    |                          the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
131 |     pub fn convert_value(&self, value: RawValue) -> Value<'_> {
    |                                                          ++++

warning: `drm` (lib) generated 1 warning
```

this pr fixes that to preempt future ci failures on the next stable rust bump in ~2w.

(note: technically `cargo +beta check` has slightly different wording, but the wording was changed and is being backported to beta before the next release)