### PR TITLE
Bump all dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: |
+          uname -a
           sudo apt-get update -y
-          sudo apt-get install -y libdrm-dev
+          sudo apt-get install -y libdrm-dev linux-headers-6.8.0-1044-azure
       - name: Fetch drm headers
         run: ./.github/workflows/fetch_headers.sh
       - uses: dtolnay/rust-toolchain@1.89.0
@@ -69,8 +70,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: |
+          uname -a
           sudo apt-get update -y
-          sudo apt-get install -y libdrm-dev
+          sudo apt-get install -y libdrm-dev linux-headers-6.8.0-1044-azure
       - name: Fetch drm headers
         run: ./.github/workflows/fetch_headers.sh
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,27 +46,23 @@ jobs:
           sudo apt-get install -y libdrm-dev
       - name: Fetch drm headers
         run: ./.github/workflows/fetch_headers.sh
-      - uses: dtolnay/rust-toolchain@1.70.0
+      - uses: dtolnay/rust-toolchain@1.89.0
         with:
           components: clippy
-        # TODO: Remove once our MSRV is past 1.84 for the new resolver
-      - uses: dtolnay/rust-toolchain@1.84.0
-      - name: Downgrade msrv aware
-        run: env CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback cargo +1.84 generate-lockfile
       - name: Cargo cache
         uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ runner.os }}-cargo-rust_1.70.0-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-rust_1.89.0-${{ hashFiles('**/Cargo.toml') }}
       - name: Build cache
         uses: actions/cache@v3
         with:
           path: target
-          key: ${{ runner.os }}-build-rust_1.70.0-check-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-build-rust_1.89.0-check-${{ hashFiles('**/Cargo.toml') }}
       - name: Clippy
-        run: cargo +1.70.0 clippy --all --all-features --all-targets -- -D warnings -A clippy::redundant_static_lifetimes
+        run: cargo +1.89.0 clippy --all --all-features --all-targets -- -D warnings -A clippy::redundant_static_lifetimes
 
   check-minimal:
     runs-on: ubuntu-22.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.15.0"
 license = "MIT"
 authors = ["Tyler Slabinski <slabity@slabity.dev>", "Victoria Brekenfeld <crates-io@drakulix.de>"]
 exclude = [".gitignore", ".github"]
-rust-version = "1.70"
+rust-version = "1.89"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ rustix = { version = "^1", features = ["mm", "fs"] }
 libc = "0.2"
 
 [dev-dependencies]
-image = { version = "0.24", default-features = false, features = ["png"] }
+image = { version = "0.25", default-features = false, features = ["png"] }
 rustix = { version = "^1", features = ["event", "mm"] }
-rustyline = "13"
+rustyline = "18"
 
 [features]
 use_bindgen = ["drm-ffi/use_bindgen"]

--- a/drm-ffi/Cargo.toml
+++ b/drm-ffi/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/Smithay/drm-rs"
 version = "0.9.1"
 license = "MIT"
 authors = ["Tyler Slabinski <tslabinski@slabity.net>"]
-rust-version = "1.70"
+rust-version = "1.89"
 edition = "2021"
 
 [dependencies]

--- a/drm-ffi/drm-sys/Cargo.toml
+++ b/drm-ffi/drm-sys/Cargo.toml
@@ -15,11 +15,11 @@ use_bindgen = ["bindgen", "pkg-config"]
 update_bindings = ["use_bindgen"]
 
 [build-dependencies]
-bindgen = { version = "0.70", optional = true }
+bindgen = { version = "0.72", optional = true }
 pkg-config = { version = "0.3.19", optional = true }
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
-linux-raw-sys = { version = "0.9", default-features = false, features = ["general", "no_std"] }
+linux-raw-sys = { version = "0.12", default-features = false, features = ["general", "no_std"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "linux")))'.dependencies]
 libc = "0.2"

--- a/drm-ffi/drm-sys/Cargo.toml
+++ b/drm-ffi/drm-sys/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.8.1"
 authors = ["Tyler Slabinski <tslabinski@slabity.net>"]
 license = "MIT"
 build = "build.rs"
-rust-version = "1.70"
+rust-version = "1.89"
 edition = "2021"
 
 [features]

--- a/examples/kms_interactive.rs
+++ b/examples/kms_interactive.rs
@@ -58,7 +58,7 @@ fn run_repl(card: &Card) {
         .edit_mode(rustyline::config::EditMode::Vi)
         .auto_add_history(true)
         .build();
-    let mut kms_editor = rustyline::Editor::<(), _>::with_config(editor_config).unwrap();
+    let mut kms_editor = rustyline::Editor::<(), _>::with_config(editor_config.clone()).unwrap();
     let mut atomic_editor = rustyline::Editor::<(), _>::with_config(editor_config).unwrap();
 
     for line in kms_editor.iter("KMS>> ").map(|x| x.unwrap()) {


### PR DESCRIPTION
Only `rustyline` required a code change.

We might want to regenerate `drm-ffi/drm-sys/src/bindings.rs` with the newer `bindgen` at some point.