### PR TITLE
Use core instead of std when possible

### DIFF
--- a/drm-ffi/src/gem.rs
+++ b/drm-ffi/src/gem.rs
@@ -5,10 +5,8 @@
 use crate::ioctl;
 use drm_sys::*;
 
-use std::{
-    io,
-    os::unix::io::{AsRawFd, BorrowedFd},
-};
+use rustix::fd::{AsRawFd, BorrowedFd};
+use std::io;
 
 /// Open a GEM object given it's 32-bit name, returning the handle.
 pub fn open(fd: BorrowedFd<'_>, name: u32) -> io::Result<drm_gem_open> {

--- a/drm-ffi/src/gem.rs
+++ b/drm-ffi/src/gem.rs
@@ -6,7 +6,7 @@ use crate::ioctl;
 use drm_sys::*;
 
 use rustix::fd::{AsRawFd, BorrowedFd};
-use std::io;
+use rustix::io;
 
 /// Open a GEM object given it's 32-bit name, returning the handle.
 pub fn open(fd: BorrowedFd<'_>, name: u32) -> io::Result<drm_gem_open> {

--- a/drm-ffi/src/ioctl.rs
+++ b/drm-ffi/src/ioctl.rs
@@ -1,6 +1,6 @@
 use core::ffi::c_uint;
 use rustix::fd::BorrowedFd;
-use std::io;
+use rustix::io;
 
 use drm_sys::*;
 use rustix::ioctl::{ioctl, opcode, Getter, NoArg, Opcode, Setter, Updater};
@@ -9,7 +9,7 @@ macro_rules! ioctl_readwrite {
     ($name:ident, $ioty:expr, $nr:expr, $ty:ty) => {
         pub unsafe fn $name(fd: BorrowedFd, data: &mut $ty) -> io::Result<()> {
             const OPCODE: Opcode = opcode::read_write::<$ty>($ioty, $nr);
-            Ok(ioctl(fd, Updater::<OPCODE, $ty>::new(data))?)
+            ioctl(fd, Updater::<OPCODE, $ty>::new(data))
         }
     };
 }
@@ -18,7 +18,7 @@ macro_rules! ioctl_read {
     ($name:ident, $ioty:expr, $nr:expr, $ty:ty) => {
         pub unsafe fn $name(fd: BorrowedFd) -> io::Result<$ty> {
             const OPCODE: Opcode = opcode::read::<$ty>($ioty, $nr);
-            Ok(ioctl(fd, Getter::<OPCODE, $ty>::new())?)
+            ioctl(fd, Getter::<OPCODE, $ty>::new())
         }
     };
 }
@@ -27,7 +27,7 @@ macro_rules! ioctl_write_ptr {
     ($name:ident, $ioty:expr, $nr:expr, $ty:ty) => {
         pub unsafe fn $name(fd: BorrowedFd, data: &$ty) -> io::Result<()> {
             const OPCODE: Opcode = opcode::write::<$ty>($ioty, $nr);
-            Ok(ioctl(fd, Setter::<OPCODE, $ty>::new(*data))?)
+            ioctl(fd, Setter::<OPCODE, $ty>::new(*data))
         }
     };
 }
@@ -36,7 +36,7 @@ macro_rules! ioctl_none {
     ($name:ident, $ioty:expr, $nr:expr) => {
         pub unsafe fn $name(fd: BorrowedFd) -> io::Result<()> {
             const OPCODE: Opcode = opcode::none($ioty, $nr);
-            Ok(ioctl(fd, NoArg::<OPCODE>::new())?)
+            ioctl(fd, NoArg::<OPCODE>::new())
         }
     };
 }

--- a/drm-ffi/src/ioctl.rs
+++ b/drm-ffi/src/ioctl.rs
@@ -1,4 +1,5 @@
-use std::{ffi::c_uint, io, os::unix::io::BorrowedFd};
+use core::ffi::c_uint;
+use std::{io, os::unix::io::BorrowedFd};
 
 use drm_sys::*;
 use rustix::ioctl::{ioctl, opcode, Getter, NoArg, Opcode, Setter, Updater};

--- a/drm-ffi/src/ioctl.rs
+++ b/drm-ffi/src/ioctl.rs
@@ -1,5 +1,6 @@
 use core::ffi::c_uint;
-use std::{io, os::unix::io::BorrowedFd};
+use rustix::fd::BorrowedFd;
+use std::io;
 
 use drm_sys::*;
 use rustix::ioctl::{ioctl, opcode, Getter, NoArg, Opcode, Setter, Updater};

--- a/drm-ffi/src/lib.rs
+++ b/drm-ffi/src/lib.rs
@@ -17,7 +17,7 @@ pub mod syncobj;
 
 use core::ffi::{c_int, c_ulong};
 use rustix::fd::BorrowedFd;
-use std::io;
+use rustix::io;
 
 ///
 /// Bindings to the methods of authentication the DRM provides.
@@ -27,7 +27,7 @@ pub mod auth {
     use drm_sys::*;
 
     use rustix::fd::BorrowedFd;
-    use std::io;
+    use rustix::io;
 
     /// Get the 'Magic Authentication Token' for this file descriptor.
     pub fn get_magic_token(fd: BorrowedFd<'_>) -> io::Result<drm_auth> {

--- a/drm-ffi/src/lib.rs
+++ b/drm-ffi/src/lib.rs
@@ -15,11 +15,8 @@ mod ioctl;
 pub mod mode;
 pub mod syncobj;
 
-use std::{
-    ffi::{c_int, c_ulong},
-    io,
-    os::unix::io::BorrowedFd,
-};
+use core::ffi::{c_int, c_ulong};
+use std::{io, os::unix::io::BorrowedFd};
 
 ///
 /// Bindings to the methods of authentication the DRM provides.

--- a/drm-ffi/src/lib.rs
+++ b/drm-ffi/src/lib.rs
@@ -2,8 +2,11 @@
 //! Foreign function interface
 //!
 
+#![no_std]
 #![warn(missing_docs)]
 #![allow(unused_doc_comments)]
+
+extern crate alloc;
 
 pub use drm_sys::{self, *};
 
@@ -15,6 +18,7 @@ mod ioctl;
 pub mod mode;
 pub mod syncobj;
 
+use alloc::vec::Vec;
 use core::ffi::{c_int, c_ulong};
 use rustix::fd::BorrowedFd;
 use rustix::io;

--- a/drm-ffi/src/lib.rs
+++ b/drm-ffi/src/lib.rs
@@ -16,7 +16,8 @@ pub mod mode;
 pub mod syncobj;
 
 use core::ffi::{c_int, c_ulong};
-use std::{io, os::unix::io::BorrowedFd};
+use rustix::fd::BorrowedFd;
+use std::io;
 
 ///
 /// Bindings to the methods of authentication the DRM provides.
@@ -25,7 +26,8 @@ pub mod auth {
     use crate::ioctl;
     use drm_sys::*;
 
-    use std::{io, os::unix::io::BorrowedFd};
+    use rustix::fd::BorrowedFd;
+    use std::io;
 
     /// Get the 'Magic Authentication Token' for this file descriptor.
     pub fn get_magic_token(fd: BorrowedFd<'_>) -> io::Result<drm_auth> {

--- a/drm-ffi/src/mode.rs
+++ b/drm-ffi/src/mode.rs
@@ -7,6 +7,7 @@
 use crate::ioctl;
 use drm_sys::*;
 
+use alloc::vec::Vec;
 use rustix::fd::BorrowedFd;
 use rustix::io;
 

--- a/drm-ffi/src/mode.rs
+++ b/drm-ffi/src/mode.rs
@@ -7,7 +7,8 @@
 use crate::ioctl;
 use drm_sys::*;
 
-use std::{io, os::unix::io::BorrowedFd};
+use rustix::fd::BorrowedFd;
+use std::io;
 
 /// Enumerate most card resources.
 pub fn get_resources(
@@ -874,7 +875,8 @@ pub mod dumbbuffer {
     use crate::ioctl;
     use drm_sys::*;
 
-    use std::{io, os::unix::io::BorrowedFd};
+    use rustix::fd::BorrowedFd;
+    use std::io;
 
     /// Create a dumb buffer
     pub fn create(

--- a/drm-ffi/src/mode.rs
+++ b/drm-ffi/src/mode.rs
@@ -8,7 +8,7 @@ use crate::ioctl;
 use drm_sys::*;
 
 use rustix::fd::BorrowedFd;
-use std::io;
+use rustix::io;
 
 /// Enumerate most card resources.
 pub fn get_resources(
@@ -876,7 +876,7 @@ pub mod dumbbuffer {
     use drm_sys::*;
 
     use rustix::fd::BorrowedFd;
-    use std::io;
+    use rustix::io;
 
     /// Create a dumb buffer
     pub fn create(

--- a/drm-ffi/src/syncobj.rs
+++ b/drm-ffi/src/syncobj.rs
@@ -5,10 +5,8 @@
 use crate::ioctl;
 use drm_sys::*;
 
-use std::{
-    io,
-    os::unix::io::{AsRawFd, BorrowedFd},
-};
+use rustix::fd::{AsRawFd, BorrowedFd};
+use std::io;
 
 /// Creates a syncobj.
 pub fn create(fd: BorrowedFd<'_>, signaled: bool) -> io::Result<drm_syncobj_create> {

--- a/drm-ffi/src/syncobj.rs
+++ b/drm-ffi/src/syncobj.rs
@@ -6,7 +6,7 @@ use crate::ioctl;
 use drm_sys::*;
 
 use rustix::fd::{AsRawFd, BorrowedFd};
-use std::io;
+use rustix::io;
 
 /// Creates a syncobj.
 pub fn create(fd: BorrowedFd<'_>, signaled: bool) -> io::Result<drm_syncobj_create> {

--- a/drm-ffi/src/utils.rs
+++ b/drm-ffi/src/utils.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 /// Takes an `Option<&mut Vec<T>>` style buffer and gets its pointer.
 macro_rules! map_ptr {
     ($buffer:expr) => {

--- a/drm-ffi/src/utils.rs
+++ b/drm-ffi/src/utils.rs
@@ -38,7 +38,7 @@ pub(crate) fn map_reserve_inner<T>(b: &mut Vec<T>, size: usize) {
     // `memset` to 0, at least so Valgrind doesn't complain
     unsafe {
         let ptr = b.as_mut_ptr().add(old_len) as *mut u8;
-        ptr.write_bytes(0, (size - old_len) * std::mem::size_of::<T>());
+        ptr.write_bytes(0, (size - old_len) * core::mem::size_of::<T>());
     }
 }
 

--- a/examples/ffi.rs
+++ b/examples/ffi.rs
@@ -1,7 +1,7 @@
 use drm_ffi as ffi;
 
+use rustix::fd::{AsFd, BorrowedFd};
 use std::fs::{File, OpenOptions};
-use std::os::unix::io::{AsFd, BorrowedFd};
 
 #[derive(Debug)]
 // This is our customized struct that implements the traits in drm.

--- a/examples/syncobj.rs
+++ b/examples/syncobj.rs
@@ -4,7 +4,7 @@ pub mod utils;
 use crate::utils::*;
 use rustix::event::PollFlags;
 use rustix::fd::{AsFd, OwnedFd};
-use std::io;
+use rustix::io;
 
 impl Card {
     fn simulate_command_submission(&self) -> io::Result<OwnedFd> {

--- a/examples/syncobj.rs
+++ b/examples/syncobj.rs
@@ -3,10 +3,8 @@ pub mod utils;
 
 use crate::utils::*;
 use rustix::event::PollFlags;
-use std::{
-    io,
-    os::unix::io::{AsFd, OwnedFd},
-};
+use rustix::fd::{AsFd, OwnedFd};
+use std::io;
 
 impl Card {
     fn simulate_command_submission(&self) -> io::Result<OwnedFd> {

--- a/examples/utils/mod.rs
+++ b/examples/utils/mod.rs
@@ -2,6 +2,7 @@
 
 pub use drm::control::Device as ControlDevice;
 pub use drm::Device;
+use rustix::fd::{AsFd, BorrowedFd};
 use std::io;
 
 #[derive(Debug)]
@@ -10,8 +11,8 @@ pub struct Card(std::fs::File);
 
 /// Implementing `AsFd` is a prerequisite to implementing the traits found
 /// in this crate. Here, we are just calling `as_fd()` on the inner File.
-impl std::os::unix::io::AsFd for Card {
-    fn as_fd(&self) -> std::os::unix::io::BorrowedFd<'_> {
+impl AsFd for Card {
+    fn as_fd(&self) -> BorrowedFd<'_> {
         self.0.as_fd()
     }
 }

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -25,6 +25,7 @@
 //!    recommended method of sharing buffers.
 
 use crate::control;
+use core::fmt;
 pub use drm_fourcc::{DrmFourcc, DrmModifier, DrmVendor, UnrecognizedFourcc, UnrecognizedVendor};
 
 /// A handle to a GEM buffer
@@ -60,8 +61,8 @@ impl From<control::RawResourceHandle> for Handle {
     }
 }
 
-impl std::fmt::Debug for Handle {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Debug for Handle {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("buffer::Handle").field(&self.0).finish()
     }
 }
@@ -83,8 +84,8 @@ impl From<Name> for u32 {
     }
 }
 
-impl std::fmt::Debug for Name {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Debug for Name {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("buffer::Name").field(&self.0).finish()
     }
 }

--- a/src/control/atomic.rs
+++ b/src/control/atomic.rs
@@ -1,6 +1,7 @@
 //! Helpers for atomic modesetting.
 
 use crate::control;
+use alloc::vec::Vec;
 
 /// Helper struct to construct atomic commit requests
 #[derive(Debug, Clone, Default)]

--- a/src/control/connector.rs
+++ b/src/control/connector.rs
@@ -7,6 +7,7 @@
 //! including the modes that the current display supports.
 
 use crate::control;
+use core::fmt;
 use drm_ffi as ffi;
 
 /// A handle to a connector
@@ -40,8 +41,8 @@ impl control::ResourceHandle for Handle {
     const FFI_TYPE: u32 = ffi::DRM_MODE_OBJECT_CONNECTOR;
 }
 
-impl std::fmt::Debug for Handle {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Debug for Handle {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("connector::Handle").field(&self.0).finish()
     }
 }
@@ -60,8 +61,8 @@ pub struct Info {
     pub(crate) subpixel: SubPixel,
 }
 
-impl std::fmt::Display for Info {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Info {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}-{}", self.interface.as_str(), self.interface_id)
     }
 }

--- a/src/control/connector.rs
+++ b/src/control/connector.rs
@@ -7,6 +7,7 @@
 //! including the modes that the current display supports.
 
 use crate::control;
+use alloc::vec::Vec;
 use core::fmt;
 use drm_ffi as ffi;
 

--- a/src/control/crtc.rs
+++ b/src/control/crtc.rs
@@ -13,6 +13,7 @@
 //! compositing.
 
 use crate::control;
+use core::fmt;
 use drm_ffi as ffi;
 
 /// A handle to a specific CRTC
@@ -46,8 +47,8 @@ impl control::ResourceHandle for Handle {
     const FFI_TYPE: u32 = ffi::DRM_MODE_OBJECT_CRTC;
 }
 
-impl std::fmt::Debug for Handle {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Debug for Handle {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("crtc::Handle").field(&self.0).finish()
     }
 }
@@ -62,8 +63,8 @@ pub struct Info {
     pub(crate) gamma_length: u32,
 }
 
-impl std::fmt::Display for Info {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Info {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "CRTC {}", self.handle.0)
     }
 }

--- a/src/control/dumbbuffer.rs
+++ b/src/control/dumbbuffer.rs
@@ -6,8 +6,8 @@
 
 use crate::buffer;
 
-use std::borrow::{Borrow, BorrowMut};
-use std::ops::{Deref, DerefMut};
+use core::borrow::{Borrow, BorrowMut};
+use core::ops::{Deref, DerefMut};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 /// Slow, but generic [`buffer::Buffer`] implementation

--- a/src/control/encoder.rs
+++ b/src/control/encoder.rs
@@ -4,6 +4,7 @@
 //! data of the CRTC and encodes it into a format the connector understands.
 
 use crate::control;
+use core::fmt;
 use drm_ffi as ffi;
 
 /// A handle to an encoder
@@ -37,8 +38,8 @@ impl control::ResourceHandle for Handle {
     const FFI_TYPE: u32 = ffi::DRM_MODE_OBJECT_ENCODER;
 }
 
-impl std::fmt::Debug for Handle {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Debug for Handle {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("encoder::Handle").field(&self.0).finish()
     }
 }
@@ -53,8 +54,8 @@ pub struct Info {
     pub(crate) pos_clones: u32,
 }
 
-impl std::fmt::Display for Info {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Info {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Encoder {}", self.handle.0)
     }
 }

--- a/src/control/framebuffer.rs
+++ b/src/control/framebuffer.rs
@@ -4,6 +4,7 @@
 
 use crate::buffer;
 use crate::control;
+use core::fmt;
 use drm_ffi as ffi;
 use drm_fourcc::{DrmFourcc, DrmModifier};
 
@@ -38,8 +39,8 @@ impl control::ResourceHandle for Handle {
     const FFI_TYPE: u32 = ffi::DRM_MODE_OBJECT_FB;
 }
 
-impl std::fmt::Debug for Handle {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Debug for Handle {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("framebuffer::Handle").field(&self.0).finish()
     }
 }
@@ -55,8 +56,8 @@ pub struct Info {
     pub(crate) buffer: Option<buffer::Handle>,
 }
 
-impl std::fmt::Display for Info {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Info {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Framebuffer {}", self.handle.0)
     }
 }

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -32,7 +32,6 @@ use drm_ffi as ffi;
 use drm_fourcc::{DrmFourcc, DrmModifier, UnrecognizedFourcc};
 
 use bytemuck::allocation::TransparentWrapperAlloc;
-use rustix::io::Errno;
 
 pub mod atomic;
 pub mod connector;
@@ -59,9 +58,9 @@ use core::ptr;
 use core::slice;
 use core::time::Duration;
 use rustix::fd::{AsFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
+use rustix::io::{self, Errno};
 use std::collections::HashMap;
 use std::error;
-use std::io;
 
 use core::num::NonZeroU32;
 
@@ -90,7 +89,7 @@ pub fn from_u32<T: From<RawResourceHandle>>(raw: u32) -> Option<T> {
 #[derive(Debug)]
 pub enum GetPlanarFramebufferError {
     /// IO error
-    Io(io::Error),
+    Io(Errno),
     /// Unrecognized fourcc format
     UnrecognizedFourcc(drm_fourcc::UnrecognizedFourcc),
 }
@@ -113,8 +112,8 @@ impl error::Error for GetPlanarFramebufferError {
     }
 }
 
-impl From<io::Error> for GetPlanarFramebufferError {
-    fn from(err: io::Error) -> Self {
+impl From<Errno> for GetPlanarFramebufferError {
+    fn from(err: Errno) -> Self {
         Self::Io(err)
     }
 }
@@ -609,7 +608,7 @@ pub trait Device: super::Device {
             || crtc_info.gamma_length as usize > green.len()
             || crtc_info.gamma_length as usize > blue.len()
         {
-            return Err(Errno::INVAL.into());
+            return Err(Errno::INVAL);
         }
 
         ffi::mode::get_gamma(
@@ -637,7 +636,7 @@ pub trait Device: super::Device {
             || crtc_info.gamma_length as usize > green.len()
             || crtc_info.gamma_length as usize > blue.len()
         {
-            return Err(Errno::INVAL.into());
+            return Err(Errno::INVAL);
         }
 
         ffi::mode::set_gamma(

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -50,16 +50,18 @@ use crate::buffer;
 
 use super::util::*;
 
+use core::ffi::CStr;
 use core::fmt;
+use core::iter::Zip;
+use core::mem;
+use core::ops::RangeBounds;
+use core::ptr;
+use core::slice;
+use core::time::Duration;
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::error;
 use std::io;
-use std::iter::Zip;
-use std::mem;
-use std::ops::RangeBounds;
 use std::os::unix::io::{AsFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
-use std::time::Duration;
 
 use core::num::NonZeroU32;
 
@@ -394,7 +396,7 @@ pub trait Device: super::Device {
     fn dirty_framebuffer(&self, handle: framebuffer::Handle, clips: &[ClipRect]) -> io::Result<()> {
         ffi::mode::dirty_fb(self.as_fd(), handle.into(), unsafe {
             // SAFETY: ClipRect is repr(transparent) for drm_clip_rect
-            core::slice::from_raw_parts(clips.as_ptr() as *const ffi::drm_clip_rect, clips.len())
+            slice::from_raw_parts(clips.as_ptr() as *const ffi::drm_clip_rect, clips.len())
         })?;
         Ok(())
     }
@@ -536,7 +538,7 @@ pub trait Device: super::Device {
     /// Create a property blob value from a given data blob
     fn create_property_blob<T: ?Sized>(&self, data: &T) -> io::Result<property::Value<'static>> {
         let size = mem::size_of_val(data);
-        let data = unsafe { std::slice::from_raw_parts_mut(data as *const _ as *mut u8, size) };
+        let data = unsafe { slice::from_raw_parts_mut(data as *const _ as *mut u8, size) };
         let blob = ffi::mode::create_property_blob(self.as_fd(), data)?;
 
         Ok(property::Value::Blob(blob.blob_id.into()))
@@ -691,12 +693,12 @@ pub trait Device: super::Device {
             let flags = mm::MapFlags::SHARED;
             let fd = self.as_fd();
             let offset = info.offset as _;
-            unsafe { mm::mmap(std::ptr::null_mut(), buffer.length, prot, flags, fd, offset)? }
+            unsafe { mm::mmap(ptr::null_mut(), buffer.length, prot, flags, fd, offset)? }
         };
 
         let mapping = DumbMapping {
-            _phantom: std::marker::PhantomData,
-            map: unsafe { std::slice::from_raw_parts_mut(map as *mut _, buffer.length) },
+            _phantom: core::marker::PhantomData,
+            map: unsafe { slice::from_raw_parts_mut(map as *mut _, buffer.length) },
         };
 
         Ok(mapping)
@@ -1139,13 +1141,12 @@ impl Iterator for Events {
     fn next(&mut self) -> Option<Event> {
         if self.amount > 0 && self.i < self.amount {
             let event_ptr = unsafe { self.event_buf.as_ptr().add(self.i) as *const ffi::drm_event };
-            let event = unsafe { std::ptr::read_unaligned(event_ptr) };
+            let event = unsafe { ptr::read_unaligned(event_ptr) };
             self.i += event.length as usize;
             match event.type_ {
                 ffi::DRM_EVENT_VBLANK => {
-                    let vblank_event = unsafe {
-                        std::ptr::read_unaligned(event_ptr as *const ffi::drm_event_vblank)
-                    };
+                    let vblank_event =
+                        unsafe { ptr::read_unaligned(event_ptr as *const ffi::drm_event_vblank) };
                     Some(Event::Vblank(VblankEvent {
                         frame: vblank_event.sequence,
                         time: Duration::new(
@@ -1158,9 +1159,8 @@ impl Iterator for Events {
                     }))
                 }
                 ffi::DRM_EVENT_FLIP_COMPLETE => {
-                    let vblank_event = unsafe {
-                        std::ptr::read_unaligned(event_ptr as *const ffi::drm_event_vblank)
-                    };
+                    let vblank_event =
+                        unsafe { ptr::read_unaligned(event_ptr as *const ffi::drm_event_vblank) };
                     Some(Event::PageFlip(PageFlipEvent {
                         frame: vblank_event.sequence,
                         duration: Duration::new(
@@ -1260,8 +1260,8 @@ pub struct Mode {
 
 impl Mode {
     /// Returns the name of this mode.
-    pub fn name(&self) -> &std::ffi::CStr {
-        unsafe { std::ffi::CStr::from_ptr(&self.mode.name[0] as _) }
+    pub fn name(&self) -> &CStr {
+        unsafe { CStr::from_ptr(&self.mode.name[0] as _) }
     }
 
     /// Returns the clock speed of this mode.
@@ -1462,8 +1462,7 @@ impl PropertyValueSet {
 
 impl<'a> IntoIterator for &'a PropertyValueSet {
     type Item = (&'a property::Handle, &'a property::RawValue);
-    type IntoIter =
-        Zip<std::slice::Iter<'a, property::Handle>, std::slice::Iter<'a, property::RawValue>>;
+    type IntoIter = Zip<slice::Iter<'a, property::Handle>, slice::Iter<'a, property::RawValue>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.prop_ids.iter().zip(self.prop_vals.iter())

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -58,10 +58,10 @@ use core::ops::RangeBounds;
 use core::ptr;
 use core::slice;
 use core::time::Duration;
+use rustix::fd::{AsFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 use std::collections::HashMap;
 use std::error;
 use std::io;
-use std::os::unix::io::{AsFd, BorrowedFd, FromRawFd, OwnedFd, RawFd};
 
 use core::num::NonZeroU32;
 

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -49,6 +49,8 @@ use crate::buffer;
 
 use super::util::*;
 
+use alloc::string::String;
+use alloc::vec::{self, Vec};
 use core::ffi::CStr;
 use core::fmt;
 use core::iter::Zip;
@@ -1470,8 +1472,7 @@ impl<'a> IntoIterator for &'a PropertyValueSet {
 
 impl IntoIterator for PropertyValueSet {
     type Item = (property::Handle, property::RawValue);
-    type IntoIter =
-        Zip<std::vec::IntoIter<property::Handle>, std::vec::IntoIter<property::RawValue>>;
+    type IntoIter = Zip<vec::IntoIter<property::Handle>, vec::IntoIter<property::RawValue>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.prop_ids.into_iter().zip(self.prop_vals)

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -50,10 +50,10 @@ use crate::buffer;
 
 use super::util::*;
 
+use core::fmt;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::error;
-use std::fmt;
 use std::io;
 use std::iter::Zip;
 use std::mem;

--- a/src/control/plane.rs
+++ b/src/control/plane.rs
@@ -16,6 +16,7 @@
 //!   cursor type objects.
 
 use crate::control;
+use core::fmt;
 use drm_ffi as ffi;
 
 /// A handle to a plane
@@ -49,8 +50,8 @@ impl control::ResourceHandle for Handle {
     const FFI_TYPE: u32 = ffi::DRM_MODE_OBJECT_PLANE;
 }
 
-impl std::fmt::Debug for Handle {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Debug for Handle {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("plane::Handle").field(&self.0).finish()
     }
 }
@@ -65,8 +66,8 @@ pub struct Info {
     pub(crate) formats: Vec<u32>,
 }
 
-impl std::fmt::Display for Info {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Info {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Plane {}", self.handle.0)
     }
 }

--- a/src/control/plane.rs
+++ b/src/control/plane.rs
@@ -16,6 +16,7 @@
 //!   cursor type objects.
 
 use crate::control;
+use alloc::vec::Vec;
 use core::fmt;
 use drm_ffi as ffi;
 

--- a/src/control/property.rs
+++ b/src/control/property.rs
@@ -12,6 +12,7 @@
 //! together and executing them all atomically.
 
 use crate::control::{RawResourceHandle, ResourceHandle};
+use core::ffi::CStr;
 use core::fmt;
 use drm_ffi as ffi;
 
@@ -72,8 +73,8 @@ impl Info {
     }
 
     /// Returns the name of this property.
-    pub fn name(&self) -> &std::ffi::CStr {
-        unsafe { std::ffi::CStr::from_ptr(&self.info.name[0] as _) }
+    pub fn name(&self) -> &CStr {
+        unsafe { CStr::from_ptr(&self.info.name[0] as _) }
     }
 
     /// Returns the ValueType of this property.
@@ -295,8 +296,8 @@ impl EnumValue {
     }
 
     /// Returns the name of this value
-    pub fn name(&self) -> &std::ffi::CStr {
-        unsafe { std::ffi::CStr::from_ptr(&self.0.name[0] as _) }
+    pub fn name(&self) -> &CStr {
+        unsafe { CStr::from_ptr(&self.0.name[0] as _) }
     }
 }
 

--- a/src/control/property.rs
+++ b/src/control/property.rs
@@ -12,6 +12,7 @@
 //! together and executing them all atomically.
 
 use crate::control::{RawResourceHandle, ResourceHandle};
+use alloc::vec::Vec;
 use core::ffi::CStr;
 use core::fmt;
 use drm_ffi as ffi;

--- a/src/control/property.rs
+++ b/src/control/property.rs
@@ -12,6 +12,7 @@
 //! together and executing them all atomically.
 
 use crate::control::{RawResourceHandle, ResourceHandle};
+use core::fmt;
 use drm_ffi as ffi;
 
 /// A raw property value that does not have a specific property type
@@ -48,8 +49,8 @@ impl ResourceHandle for Handle {
     const FFI_TYPE: u32 = ffi::DRM_MODE_OBJECT_PROPERTY;
 }
 
-impl std::fmt::Debug for Handle {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Debug for Handle {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("property::Handle").field(&self.0).finish()
     }
 }
@@ -305,8 +306,8 @@ impl From<ffi::drm_mode_property_enum> for EnumValue {
     }
 }
 
-impl std::fmt::Debug for EnumValue {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Debug for EnumValue {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("EnumValue")
             .field("value", &self.value())
             .field("name", &self.name())

--- a/src/control/syncobj.rs
+++ b/src/control/syncobj.rs
@@ -13,6 +13,7 @@
 //! [`tokio::io::unix::AsyncFd`]: <https://docs.rs/tokio/latest/tokio/io/unix/struct.AsyncFd.html>
 
 use crate::control;
+use core::fmt;
 
 /// A handle to a specific syncobj
 #[repr(transparent)]
@@ -42,8 +43,8 @@ impl From<control::RawResourceHandle> for Handle {
     }
 }
 
-impl std::fmt::Debug for Handle {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Debug for Handle {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("syncobj::Handle").field(&self.0).finish()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,11 +36,9 @@ pub mod node;
 
 use core::time::Duration;
 use std::ffi::{OsStr, OsString};
-use std::{
-    io,
-    os::unix::{ffi::OsStringExt, io::AsFd},
-};
+use std::{io, os::unix::ffi::OsStringExt};
 
+use rustix::fd::AsFd;
 use rustix::io::Errno;
 
 use crate::util::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,10 +36,10 @@ pub mod node;
 
 use core::time::Duration;
 use std::ffi::{OsStr, OsString};
-use std::{io, os::unix::ffi::OsStringExt};
+use std::os::unix::ffi::OsStringExt;
 
 use rustix::fd::AsFd;
-use rustix::io::Errno;
+use rustix::io::{self, Errno};
 
 use crate::util::*;
 
@@ -199,7 +199,7 @@ pub trait Device: AsFd {
 
         let high_crtc_mask = _DRM_VBLANK_HIGH_CRTC_MASK >> _DRM_VBLANK_HIGH_CRTC_SHIFT;
         if (high_crtc & !high_crtc_mask) != 0 {
-            return Err(Errno::INVAL.into());
+            return Err(Errno::INVAL);
         }
 
         let (sequence, wait_type) = match target_sequence {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,8 @@ pub mod buffer;
 pub mod control;
 pub mod node;
 
+use core::time::Duration;
 use std::ffi::{OsStr, OsString};
-use std::time::Duration;
 use std::{
     io,
     os::unix::{ffi::OsStringExt, io::AsFd},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,12 +28,15 @@
 
 #![warn(missing_docs)]
 
+extern crate alloc;
+
 pub(crate) mod util;
 
 pub mod buffer;
 pub mod control;
 pub mod node;
 
+use alloc::vec::Vec;
 use core::time::Duration;
 use std::ffi::{OsStr, OsString};
 use std::os::unix::ffi::OsStringExt;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -3,6 +3,7 @@
 pub mod constants;
 
 use core::fmt;
+use rustix::io::Errno;
 use std::error::Error;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -22,13 +23,13 @@ pub struct DrmNode {
 impl DrmNode {
     /// Creates a DRM node from an open drm device.
     pub fn from_file<A: AsFd>(file: A) -> Result<DrmNode, CreateDrmNodeError> {
-        let stat = fstat(file).map_err(Into::<io::Error>::into)?;
+        let stat = fstat(file)?;
         DrmNode::from_stat(stat)
     }
 
     /// Creates a DRM node from path.
     pub fn from_path<A: AsRef<Path>>(path: A) -> Result<DrmNode, CreateDrmNodeError> {
-        let stat = stat(path.as_ref()).map_err(Into::<io::Error>::into)?;
+        let stat = stat(path.as_ref())?;
         DrmNode::from_stat(stat)
     }
 
@@ -187,7 +188,7 @@ impl fmt::Display for NodeType {
 #[derive(Debug)]
 pub enum CreateDrmNodeError {
     /// Some underlying IO error occured while trying to create a DRM node.
-    Io(io::Error),
+    Io(Errno),
 
     /// The provided file descriptor does not refer to a DRM node.
     NotDrmNode,
@@ -213,9 +214,9 @@ impl Error for CreateDrmNodeError {
     }
 }
 
-impl From<io::Error> for CreateDrmNodeError {
+impl From<Errno> for CreateDrmNodeError {
     #[inline]
-    fn from(err: io::Error) -> Self {
+    fn from(err: Errno) -> Self {
         CreateDrmNodeError::Io(err)
     }
 }
@@ -275,7 +276,7 @@ pub fn is_device_drm(dev: dev_t) -> bool {
 
 /// Returns the path of a specific type of node from the same DRM device as another path of the same node.
 pub fn path_to_type<P: AsRef<Path>>(path: P, ty: NodeType) -> io::Result<PathBuf> {
-    let stat = stat(path.as_ref()).map_err(Into::<io::Error>::into)?;
+    let stat = stat(path.as_ref())?;
     dev_path(stat.st_rdev, ty)
 }
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod constants;
 
+use alloc::format;
 use core::fmt;
 use rustix::io::Errno;
 use std::error::Error;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -2,8 +2,8 @@
 
 pub mod constants;
 
+use core::fmt;
 use std::error::Error;
-use std::fmt::{self, Debug, Display, Formatter};
 use std::io;
 use std::os::unix::io::AsFd;
 use std::path::{Path, PathBuf};
@@ -105,8 +105,8 @@ impl DrmNode {
     }
 }
 
-impl Display for DrmNode {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Display for DrmNode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}{}", self.ty.minor_name_prefix(), minor(self.dev_id()))
     }
 }
@@ -177,9 +177,9 @@ impl NodeType {
     }
 }
 
-impl Display for NodeType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        Debug::fmt(self, f)
+impl fmt::Display for NodeType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
     }
 }
 
@@ -193,10 +193,10 @@ pub enum CreateDrmNodeError {
     NotDrmNode,
 }
 
-impl Display for CreateDrmNodeError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+impl fmt::Display for CreateDrmNodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Io(err) => Display::fmt(err, f),
+            Self::Io(err) => fmt::Display::fmt(err, f),
             Self::NotDrmNode => {
                 f.write_str("the provided file descriptor does not refer to a DRM node")
             }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -5,9 +5,9 @@ pub mod constants;
 use core::fmt;
 use std::error::Error;
 use std::io;
-use std::os::unix::io::AsFd;
 use std::path::{Path, PathBuf};
 
+use rustix::fd::AsFd;
 use rustix::fs::{fstat, major, minor, stat, Dev as dev_t, Stat};
 
 use crate::node::constants::*;

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,7 @@
 use crate::control::{from_u32, RawResourceHandle};
 
 pub unsafe fn transmute_vec<T, U>(from: Vec<T>) -> Vec<U> {
-    let mut from = std::mem::ManuallyDrop::new(from);
+    let mut from = core::mem::ManuallyDrop::new(from);
 
     Vec::from_raw_parts(from.as_mut_ptr() as *mut U, from.len(), from.capacity())
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,7 @@
 //! Utilities used internally by this crate.
 
 use crate::control::{from_u32, RawResourceHandle};
+use alloc::vec::Vec;
 
 pub unsafe fn transmute_vec<T, U>(from: Vec<T>) -> Vec<U> {
     let mut from = core::mem::ManuallyDrop::new(from);


### PR DESCRIPTION
We were previously importing many things from `std` even though they are available in `core`, this will eventually help `no_std` support.