### PR TITLE
Update image dev-dependency to 0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rustix = { version = "1.0.7", features = ["mm", "fs"] }
 libc = "0.2"
 
 [dev-dependencies]
-image = { version = "0.24", default-features = false, features = ["png"] }
+image = { version = "0.25", default-features = false, features = ["png"] }
 rustix = { version = "1.0.7", features = ["event", "mm"] }
 rustyline = "13"
 


### PR DESCRIPTION
https://github.com/image-rs/image/blob/v0.25.9/CHANGES.md#version-0250

The dev-dependency is used only for examples, and `cargo test --examples` still completes successfully.