### PR TITLE
Add `is_empty` method to `AtomicModeReq`

### DIFF
--- a/src/control/atomic.rs
+++ b/src/control/atomic.rs
@@ -17,6 +17,11 @@ impl AtomicModeReq {
         Self::default()
     }
 
+    /// Return `true` if the request is empty
+    pub fn is_empty(&self) -> bool {
+        self.objects.is_empty()
+    }
+
     /// Add a property and value pair for a given raw resource to the request
     pub fn add_raw_property(
         &mut self,


### PR DESCRIPTION
This allows unnecessary `ioctl` system calls to be avoided if the request is empty. For example:

```rust
let mut req = AtomicModeReq::new();

if foo {
    req.add_raw_property(...);
}

if bar {
    req.add_raw_property(...);
}

if !req.is_empty() {
    device.atomic_commit(..., req);
}
```