### PR TITLE
upgrade rustyline to version 18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ libc = "0.2"
 [dev-dependencies]
 image = { version = "0.24", default-features = false, features = ["png"] }
 rustix = { version = "^1", features = ["event", "mm"] }
-rustyline = "13"
+rustyline = "18"
 
 [features]
 use_bindgen = ["drm-ffi/use_bindgen"]

--- a/examples/kms_interactive.rs
+++ b/examples/kms_interactive.rs
@@ -58,7 +58,7 @@ fn run_repl(card: &Card) {
         .edit_mode(rustyline::config::EditMode::Vi)
         .auto_add_history(true)
         .build();
-    let mut kms_editor = rustyline::Editor::<(), _>::with_config(editor_config).unwrap();
+    let mut kms_editor = rustyline::Editor::<(), _>::with_config(editor_config.clone()).unwrap();
     let mut atomic_editor = rustyline::Editor::<(), _>::with_config(editor_config).unwrap();
 
     for line in kms_editor.iter("KMS>> ").map(|x| x.unwrap()) {


### PR DESCRIPTION
based on: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/drm/debian/patches/rustyline-17.patch?ref_type=heads