### PR TITLE
Avoid requiring two versions of `linux-raw-sys`.

### DIFF
--- a/drm-ffi/drm-sys/Cargo.toml
+++ b/drm-ffi/drm-sys/Cargo.toml
@@ -19,7 +19,7 @@ bindgen = { version = "0.70", optional = true }
 pkg-config = { version = "0.3.19", optional = true }
 
 [target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
-linux-raw-sys = { version = "0.9", default-features = false, features = ["general", "no_std"] }
+linux-raw-sys = { version = "0.12", default-features = false, features = ["general", "no_std"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "linux")))'.dependencies]
 libc = "0.2"


### PR DESCRIPTION
Update `drm-sys` to depend on `linux-raw-sys` 0.12, to avoid requiring both version 0.9 and version 0.12 of `linux-raw-sys`. Before this patch, the situation is (abridged):

```
├── drm-ffi v0.9.1 (/home/jimb/drm-rs/drm-ffi)
│   ├── drm-sys v0.8.1 (/home/jimb/drm-rs/drm-ffi/drm-sys)
│   │   └── linux-raw-sys v0.9.4
│   └── rustix v1.1.4
│       └── linux-raw-sys v0.12.1
```

Tested with `cargo clippy --workspace --all-features`.