### PR TITLE
Rename macro `map_len` to `map_capacity`, to match Rust terminology.

### DIFF
--- a/drm-ffi/src/lib.rs
+++ b/drm-ffi/src/lib.rs
@@ -167,11 +167,11 @@ pub fn get_version(
     map_reserve!(desc_buf, sizes.desc_len as usize);
 
     let mut version = drm_version {
-        name_len: map_len!(&name_buf),
+        name_len: map_capacity!(&name_buf),
         name: map_ptr!(&name_buf),
-        date_len: map_len!(&date_buf),
+        date_len: map_capacity!(&date_buf),
         date: map_ptr!(&date_buf),
-        desc_len: map_len!(&desc_buf),
+        desc_len: map_capacity!(&desc_buf),
         desc: map_ptr!(&desc_buf),
         ..Default::default()
     };

--- a/drm-ffi/src/mode.rs
+++ b/drm-ffi/src/mode.rs
@@ -32,10 +32,10 @@ pub fn get_resources(
         crtc_id_ptr: map_ptr!(&crtcs),
         connector_id_ptr: map_ptr!(&connectors),
         encoder_id_ptr: map_ptr!(&encoders),
-        count_fbs: map_len!(&fbs),
-        count_crtcs: map_len!(&crtcs),
-        count_connectors: map_len!(&connectors),
-        count_encoders: map_len!(&encoders),
+        count_fbs: map_capacity!(&fbs),
+        count_crtcs: map_capacity!(&crtcs),
+        count_connectors: map_capacity!(&connectors),
+        count_encoders: map_capacity!(&encoders),
         ..Default::default()
     };
 
@@ -429,8 +429,8 @@ pub fn get_connector(
                 Some(b) => b.capacity() as _,
                 None => u32::from(!force_probe),
             },
-            count_props: map_len!(&props),
-            count_encoders: map_len!(&encoders),
+            count_props: map_capacity!(&props),
+            count_encoders: map_capacity!(&encoders),
             ..Default::default()
         };
 
@@ -693,7 +693,7 @@ pub fn get_properties(
     let mut info = drm_mode_obj_get_properties {
         props_ptr: map_ptr!(&props),
         prop_values_ptr: map_ptr!(&values),
-        count_props: map_len!(&props),
+        count_props: map_capacity!(&props),
         obj_id,
         obj_type,
     };
@@ -815,7 +815,7 @@ pub fn list_lessees(
 
     let mut data = drm_mode_list_lessees {
         lessees_ptr: map_ptr!(&lessees),
-        count_lessees: map_len!(&lessees),
+        count_lessees: map_capacity!(&lessees),
         ..Default::default()
     };
 
@@ -842,7 +842,7 @@ pub fn get_lease(
     map_reserve!(objects, sizes.count_objects as usize);
 
     let mut data = drm_mode_get_lease {
-        count_objects: map_len!(&objects),
+        count_objects: map_capacity!(&objects),
         objects_ptr: map_ptr!(&objects),
         ..Default::default()
     };

--- a/drm-ffi/src/utils.rs
+++ b/drm-ffi/src/utils.rs
@@ -9,7 +9,7 @@ macro_rules! map_ptr {
 }
 
 /// Takes an `Option<&mut Vec<T>>` style buffer and gets its allocated length.
-macro_rules! map_len {
+macro_rules! map_capacity {
     ($buffer:expr) => {
         match $buffer {
             Some(b) => b.capacity() as _,


### PR DESCRIPTION
In `drm_ffi::utils`, rename the macro `map_len` to `map_capacity`, as it returns the capacity of the vector, not its length. The DRM types don't seem to use the term "length" or "len" either, so the old name doesn't match either Rust's or DRM's conventions.

Tested with `cargo clippy --all-features --workspace`.