### PR TITLE
add patch for build crate in e2k cpu architecture

### DIFF
--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,5 +1,4 @@
 //! Module for abstractions on drm device nodes.
-#![allow(unexpected_cfgs)]
 
 pub mod constants;
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,4 +1,5 @@
 //! Module for abstractions on drm device nodes.
+#![allow(unexpected_cfgs)]
 
 pub mod constants;
 
@@ -34,7 +35,17 @@ impl DrmNode {
 
     /// Creates a DRM node from a file stat.
     pub fn from_stat(stat: Stat) -> Result<DrmNode, CreateDrmNodeError> {
-        let dev = stat.st_rdev;
+        let dev: u64 = {
+            #[cfg(not(target_arch = "e2k"))]
+            {
+                stat.st_rdev
+            }
+
+            #[cfg(target_arch = "e2k")]
+            {
+                stat.st_rdev as u64
+            }
+        };
         DrmNode::from_dev_id(dev)
     }
 
@@ -276,7 +287,18 @@ pub fn is_device_drm(dev: dev_t) -> bool {
 /// Returns the path of a specific type of node from the same DRM device as another path of the same node.
 pub fn path_to_type<P: AsRef<Path>>(path: P, ty: NodeType) -> io::Result<PathBuf> {
     let stat = stat(path.as_ref()).map_err(Into::<io::Error>::into)?;
-    dev_path(stat.st_rdev, ty)
+    let dev: u64 = {
+        #[cfg(not(target_arch = "e2k"))]
+        {
+            stat.st_rdev
+        }
+
+        #[cfg(target_arch = "e2k")]
+        {
+            stat.st_rdev as u64
+        }
+    };
+    dev_path(dev, ty)
 }
 
 /// Returns the path of a specific type of node from the same DRM device as an existing [`DrmNode`].

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -35,17 +35,9 @@ impl DrmNode {
 
     /// Creates a DRM node from a file stat.
     pub fn from_stat(stat: Stat) -> Result<DrmNode, CreateDrmNodeError> {
-        let dev: u64 = {
-            #[cfg(not(target_arch = "e2k"))]
-            {
-                stat.st_rdev
-            }
-
-            #[cfg(target_arch = "e2k")]
-            {
-                stat.st_rdev as u64
-            }
-        };
+        // Hack (u64 as u64) for E2K CPU architecture
+        #[allow(clippy::unnecessary_cast)]
+        let dev = stat.st_rdev as u64;
         DrmNode::from_dev_id(dev)
     }
 
@@ -287,17 +279,9 @@ pub fn is_device_drm(dev: dev_t) -> bool {
 /// Returns the path of a specific type of node from the same DRM device as another path of the same node.
 pub fn path_to_type<P: AsRef<Path>>(path: P, ty: NodeType) -> io::Result<PathBuf> {
     let stat = stat(path.as_ref()).map_err(Into::<io::Error>::into)?;
-    let dev: u64 = {
-        #[cfg(not(target_arch = "e2k"))]
-        {
-            stat.st_rdev
-        }
-
-        #[cfg(target_arch = "e2k")]
-        {
-            stat.st_rdev as u64
-        }
-    };
+    // Hack (u64 as u64) for E2K CPU architecture
+    #[allow(clippy::unnecessary_cast)]
+    let dev = stat.st_rdev as u64;
     dev_path(dev, ty)
 }
 


### PR DESCRIPTION
Good afternoon!

When generating code for the "linux-raw-sys" crate using "bindgen" on the "E2K (Elbrus 2000)" processor architecture, one of the types for the "st_rdev" field does not match the type implemented for the "x86_64" architecture (u32 instead of u64). A small  patch is required to fix the error.
